### PR TITLE
Change name label to 'pagename' in new page dialog

### DIFF
--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -94,7 +94,7 @@
 		html = '<table class="section"><tr><th colspan="2"><?=__('create-new-page')?></td><tr>';
 		// TODO [LRM]: find better way to set default new page type.
 		html+= '<tr><th><?=__('type')?></th><td><select id="newPageType" name="newPageType">' + '<?php foreach($types as $type => $datatypeName) echo '<option value="'.$type.'"'.($type=='textpage' ? 'selected="selected"' : '').'>'.$datatypeName.'</option>'; ?>' + '</select></td></tr>';
-		html+= '<tr><th><?=__('name')?></th><td><input type="text" id="newPagename" value="<?=$pagename?>" onblur="validatePagename(this);" onkeyup="validatePagename(this); document.getElementById(\'newPageSubmit\').disabled = this.value ? false : true;"/></td></tr>';
+		html+= '<tr><th><?=__('pagename')?></th><td><input type="text" id="newPagename" value="<?=$pagename?>" onblur="validatePagename(this);" onkeyup="validatePagename(this); document.getElementById(\'newPageSubmit\').disabled = this.value ? false : true;"/></td></tr>';
 		html+= '<tr><td></td><td><input type="checkbox" id="newPagePrivate" name="newPagePrivate"/> <?=__('private-page')?></td></tr>';
 		html+= '<tr><td></td><td><input type="button" class="button" value="<?=__('cancel')?>" onclick="document.getElementById(\'popup\').style.visibility=\'hidden\';" />';
 		html+= '<input type="submit" id="newPageSubmit" class="button editButton" value="<?=__('create')?>" <?= $pagename ? '' : 'disabled="true"' ?> onclick="hypha(\'<?=$hyphaContentLanguage?>/\' + document.getElementById(\'newPagename\').value + \'/edit\', \'newPage\', document.getElementById(\'newPagename\').value);" /></td></tr></table>';

--- a/system/languages/en.php
+++ b/system/languages/en.php
@@ -17,6 +17,7 @@
 		"login-failed" => "login failed. If you forgot your password, click here: ",
 		"reregister" => "recover account",
 		"name" => "name",
+		"pagename" => "pagename",
 		"username" => "username",
 		"fullname" => "full name",
 		"password" => "password",

--- a/system/languages/nl.php
+++ b/system/languages/nl.php
@@ -17,6 +17,7 @@
 		"login-failed" => "inloggen mislukt. Klik hier als je je wachtwoord bent vergeten: ",
 		"reregister" => "heraanmelden",
 		"name" => "naam",
+		"pagename" => "paginanaam",
 		"username" => "gebruikersnaam",
 		"fullname" => "volledige naam",
 		"password" => "wachtwoord",


### PR DESCRIPTION
User filled in their own name, where pagename was intended.

This fixes #111.