### PR TITLE
Bugfix for duplicate To: header error message

### DIFF
--- a/system/core/communication.php
+++ b/system/core/communication.php
@@ -56,7 +56,7 @@
 				$error[] = $receiver;
 				continue;
 			}
-			$success = mail($receiver, $subject, $messageHtml, $headers . 'To: ' . $receiver, '-f ' . $senderEmail);
+			$success = mail($receiver, $subject, $messageHtml, $headers, '-f '.$senderEmail);
 			if (!$success) {
 				$error[] = $receiver;
 			}


### PR DESCRIPTION
In the sendMail function (in system/core/communication.php) a To: field was added to the header-string passed to php's mail function. This results in a redundant To: header in addition to the To: header that the mail function creates from its first argument. I simply removed the additional To: header.
I'm not sure why the additional To: header was added in the original code, if it is perhaps needed to ensure proper sending of email or if there might be a difference in behaviour between versions of php. Also I couldn't reproduce the error (or test this fix for that matter) on any email account at my disposal. However, this could fix #143 and as far as I could test email is still getting sent fine after this patch.