### PR TITLE
Moved generation of notify div element from php code to hypha.html

### DIFF
--- a/data/themes/default/hypha.css
+++ b/data/themes/default/hypha.css
@@ -652,6 +652,10 @@ img.centered{
  background: #FFC0CB;
 }
 
+#hyphaNotify:empty{
+	visibility: hidden;
+}
+
 .success {
  padding: 10px;
  background: #00FFCB;

--- a/data/themes/default/hypha.html
+++ b/data/themes/default/hypha.html
@@ -24,6 +24,7 @@
         </div>
         -->
         <div id="page">
+          <div id="hyphaNotify" />
           <div id="pageCommands" />
           <div class="flex between">
             <div class="pageTitle">

--- a/system/core/events.php
+++ b/system/core/events.php
@@ -396,7 +396,6 @@
 		$body = $html->getElementsByTagName('body')->Item(0);
 		$msgdiv = $html->createElement('div', '');
 		$msgdiv->setAttribute('id', 'hyphaNotify');
-		$msgdiv->setAttribute('style', 'visibility:'.(count($hyphaNotificationList)?'visible':'hidden').';');
 		$body->appendChild($msgdiv);
 
 		// Show any notifications from before a redirect. The
@@ -457,10 +456,8 @@
 				}
 			}
 			if (msgbox.children.length) {
-				document.getElementById('hyphaNotify').style.visibility = 'visible';
 				setTimeout(notifyTimer, 100);
 			}
-			else document.getElementById('hyphaNotify').style.visibility = 'hidden';
 		}
 	}
 	setTimeout(notifyTimer, 1000);

--- a/system/core/events.php
+++ b/system/core/events.php
@@ -392,11 +392,6 @@
 	$GLOBALS['hyphaNotificationList'] = array();
 	function addNotifier($html) {
 		global $hyphaNotificationList;
-		// add hyphaNotify element to body
-		$body = $html->getElementsByTagName('body')->Item(0);
-		$msgdiv = $html->createElement('div', '');
-		$msgdiv->setAttribute('id', 'hyphaNotify');
-		$body->appendChild($msgdiv);
 
 		// Show any notifications from before a redirect. The
 		// notifications themselves are stored in the session

--- a/system/core/events.php
+++ b/system/core/events.php
@@ -411,6 +411,13 @@
 			session_write_close();
 		}
 
+
+		// Compatibility for older version that did not have the
+		// #hyphaNotify element in their html. Add to the
+		// header, to ensure it will be seen.
+		if (!$html->getElementById('hyphaNotify'))
+			$html->writeToElement('header', '<div id="hyphaNotify"></div>');
+
 		if (count($hyphaNotificationList))
 			foreach ($hyphaNotificationList as $msg)
 				$html->writeToElement('hyphaNotify', $msg);

--- a/system/datatypes/settings.php
+++ b/system/datatypes/settings.php
@@ -208,7 +208,7 @@
 					writeToDigest($user->getAttribute('fullname').' '.__('has-joined'), 'settings');
 					notify('success', __('registration-successful'));
 					$hyphaXml->saveAndUnlock();
-					return 'reload';
+					return ['redirect', $hyphaUrl];
 				}
 			}
 			$hyphaXml->unlock();


### PR DESCRIPTION
The div element with id 'hyphaNotify' was generated dynamically in the function
addNotifier in events.php and added to the end of the DOM document. Now it is
included in the default hypha.html document to facilitate styling.