### PR TITLE
More comment fixes for peer reviewed article

### DIFF
--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -817,12 +817,12 @@ class peer_reviewed_article extends Page {
 
 		// process form if it was posted
 		if ($formPosted && empty($form->errors)) {
-			$container = $type === 'review' ? self::FIELD_NAME_DISCUSSION_REVIEW_CONTAINER : self::FIELD_NAME_DISCUSSION_PUBLIC_CONTAINER;
+			$container = $review ? self::FIELD_NAME_DISCUSSION_REVIEW_CONTAINER : self::FIELD_NAME_DISCUSSION_PUBLIC_CONTAINER;
 			$discussions = $this->getDocPageByName($container);
 			$discussion = $discussions->createChild(self::FIELD_NAME_DISCUSSION);
 			$blocking = $form->dataFor(self::FIELD_NAME_DISCUSSION_BLOCKING) !== null;
 			$discussion->setAttr(self::FIELD_NAME_DISCUSSION_BLOCKING, $blocking);
-			if ($type === 'review') {
+			if ($review) {
 				$discussion->setAttr(self::FIELD_NAME_USER, $this->hyphaUser->getAttribute('id'));
 			}
 			if ($blocking) {

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -833,7 +833,8 @@ class peer_reviewed_article extends Page {
 			$comment = $this->createDiscussionComment($discussion, $commentText, $form);
 			$this->saveAndUnlock();
 			$this->resetDocPagesMtx();
-			$this->fireEvent(self::EVENT_PUBLIC_COMMENT, ['id' => $comment->getId()]);
+			if (!$review)
+				$this->fireEvent(self::EVENT_PUBLIC_COMMENT, ['id' => $comment->getId()]);
 			$this->fireEvent(self::EVENT_DISCUSSION_STARTED, ['id' => $discussion->getId()]);
 			notify('success', ucfirst(__('art-successfully-updated')));
 			return ['redirect', $this->constructFullPath($this->pagename)];
@@ -875,7 +876,8 @@ class peer_reviewed_article extends Page {
 			$comment = $this->createDiscussionComment($discussion, $commentText, $form);
 			$this->saveAndUnlock();
 			$this->resetDocPagesMtx();
-			$this->fireEvent(self::EVENT_PUBLIC_COMMENT, ['id' => $comment->getId()]);
+			if (!$review)
+				$this->fireEvent(self::EVENT_PUBLIC_COMMENT, ['id' => $comment->getId()]);
 			notify('success', ucfirst(__('art-successfully-updated')));
 			return ['redirect', $this->constructFullPath($this->pagename)];
 		}

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -833,6 +833,7 @@ class peer_reviewed_article extends Page {
 			$comment = $this->createDiscussionComment($discussion, $commentText, $form);
 			$this->saveAndUnlock();
 			$this->resetDocPagesMtx();
+			$this->fireEvent(self::EVENT_PUBLIC_COMMENT, ['id' => $comment->getId()]);
 			$this->fireEvent(self::EVENT_DISCUSSION_STARTED, ['id' => $discussion->getId()]);
 			notify('success', ucfirst(__('art-successfully-updated')));
 			return ['redirect', $this->constructFullPath($this->pagename)];

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -492,12 +492,14 @@ class peer_reviewed_article extends Page {
 
 		if (!(bool)$comment->getAttribute(self::FIELD_NAME_DISCUSSION_COMMENT_PENDING)) {
 			$this->xml->unlock();
-			notify('success', ucfirst(__('art-comment-received')));
+			notify('success', ucfirst(__('art-comment-posted')));
 			return ['redirect', $this->constructFullPath($this->pagename)];
 		}
 
 		$comment->setAttribute(self::FIELD_NAME_DISCUSSION_COMMENT_PENDING, false);
 		$this->xml->saveAndUnlock();
+
+		notify('success', ucfirst(__('art-comment-posted')));
 
 		// send message when comment was confirmed by a visitor
 		$this->sendNewCommentMessage($comment);
@@ -833,10 +835,18 @@ class peer_reviewed_article extends Page {
 			$comment = $this->createDiscussionComment($discussion, $commentText, $form);
 			$this->saveAndUnlock();
 			$this->resetDocPagesMtx();
+			$pending = (bool)$comment->getAttr(self::FIELD_NAME_DISCUSSION_COMMENT_PENDING);
 			if (!$review)
 				$this->fireEvent(self::EVENT_PUBLIC_COMMENT, ['id' => $comment->getId()]);
 			$this->fireEvent(self::EVENT_DISCUSSION_STARTED, ['id' => $discussion->getId()]);
-			notify('success', ucfirst(__('art-successfully-updated')));
+			// TODO: the event handler sends the
+			// confirmation mail, but we notify the user.
+			// Would be better to have more coupling between
+			// those.
+			if ($pending)
+				notify('success', ucfirst(__('art-comment-pending')));
+			else
+				notify('success', ucfirst(__('art-comment-posted')));
 			return ['redirect', $this->constructFullPath($this->pagename)];
 		}
 		$this->unlock();
@@ -876,9 +886,17 @@ class peer_reviewed_article extends Page {
 			$comment = $this->createDiscussionComment($discussion, $commentText, $form);
 			$this->saveAndUnlock();
 			$this->resetDocPagesMtx();
+			$pending = (bool)$comment->getAttr(self::FIELD_NAME_DISCUSSION_COMMENT_PENDING);
 			if (!$review)
 				$this->fireEvent(self::EVENT_PUBLIC_COMMENT, ['id' => $comment->getId()]);
-			notify('success', ucfirst(__('art-successfully-updated')));
+			// TODO: the event handler sends the
+			// confirmation mail, but we notify the user.
+			// Would be better to have more coupling between
+			// those.
+			if ($pending)
+				notify('success', ucfirst(__('art-comment-pending')));
+			else
+				notify('success', ucfirst(__('art-comment-posted')));
 			return ['redirect', $this->constructFullPath($this->pagename)];
 		}
 		$this->unlock();

--- a/system/languages/en.php
+++ b/system/languages/en.php
@@ -296,6 +296,8 @@
 		"art-the-status-of-an-article-has-been-updated" => "The status of an article has been updated",
 		"art-status-update-subject" => "Status update article: [[title]]",
 		"art-status-update-body" => "The article with the title:<br /><br /><a href=\"[[link]]\">[[title]]</a><br /><br />changed status. The current status is:<br /><br />[[status]]",
+		"art-review-request-subject" => "Article ready for review: [[title]]",
+		"art-review-request-body" => "The article with the title:<br /><br /><a href=\"[[link]]\">[[title]]</a><br /><br />is now ready for review",
 		"art-block-submitted-subject" => "A blocking comment was added to: [[title]]",
 		"art-block-submitted-body" => "A blocking comment was added by [[author]] to:<br /><br /><a href=\"[[link]]\">[[title]]</a>",
 		"art-block-resolved-subject" => "Blocking comment resolved: [[title]]",

--- a/system/languages/en.php
+++ b/system/languages/en.php
@@ -287,7 +287,8 @@
 		"art-unsupported-status-change" => "this status change is not supported",
 		"art-no-approves-yet" => "there are no approves yet",
 		"art-successfully-updated" => "successfully updated",
-		"art-comment-received" => "Your comment has been received. You will receive a mail for confirmation. Click on the link in this mail to publish your comment.",
+		"art-comment-pending" => "Your comment has been received. You will receive a mail for confirmation. Click on the link in this mail to publish your comment.",
+		"art-comment-posted" => "Your comment has been posted.",
 		"art-status-changed-in-between" => "the status has been changed in between",
 
 		// peer_reviewed_article - mail

--- a/system/languages/nl.php
+++ b/system/languages/nl.php
@@ -291,6 +291,8 @@
 		"art-the-status-of-an-article-has-been-updated" => "De status van een artikel is geüpdate",
 		"art-status-update-subject" => "Status '[[status]]' voor '[[title]]'",
 		"art-status-update-body" => "De status van het artikel '<a href=\"[[link]]\">[[title]]</a>' is veranderd in '[[status]]'.<br />------------------------------<br />Dit is een geautomatiseerde mail. Antwoorden hierop heeft geen zin.",
+		"art-review-request-subject" => "Artikel klaar voor review: '[[title]]'",
+		"art-review-request-body" => "Het artikel '<a href=\"[[link]]\">[[title]]</a>' is klaar voor review.<br />------------------------------<br />Dit is een geautomatiseerde mail. Antwoorden hierop heeft geen zin.",
 		"art-block-submitted-subject" => "Nieuw breekpunt bij '[[title]]'",
 		"art-block-submitted-body" => "[[author]] voegde een breekpunt toe aan '<a href=\"[[link]]\">[[title]]</a>'.<br /><br />[[comment]]<br />------------------------------<br />Dit is een geautomatiseerde mail. Antwoorden hierop heeft geen zin.",
 		"art-block-resolved-subject" => "Breekpunt opgelost bij '[[title]]'",

--- a/system/languages/nl.php
+++ b/system/languages/nl.php
@@ -282,7 +282,8 @@
 		"art-unsupported-status-change" => "deze status verandering wordt niet ondersteund",
 		"art-no-approves-yet" => "er zijn nog geen goedkeuringen ontvangen",
 		"art-successfully-updated" => "succesvol bijgewerkt",
-		"art-comment-received" => "Uw reactie is ontvangen. U krijgt zo een mail toegestuurd. klik op de link in die mail om de plaatsing definitief te maken. ",
+		"art-comment-pending" => "Uw reactie is ontvangen. U krijgt zo een mail toegestuurd. klik op de link in die mail om de plaatsing definitief te maken.",
+		"art-comment-posted" => "Uw reactie is geplaatst.",
 		"art-status-changed-in-between" => "de status is tussentijds aangepast",
 
 		// peer_reviewed_article - mail


### PR DESCRIPTION
This makes a few more fixes to the handling of article comments, and fixes some incorrect previous fixes. With this applied, master should be free of regressions again.