### PR TITLE
Article buttons at end

### DIFF
--- a/data/themes/default/hypha.html
+++ b/data/themes/default/hypha.html
@@ -15,7 +15,7 @@
       <div id="trail" />
       <div id="log" />
     </div>
-    <div class="container pageContainer">      
+    <div class="container pageContainer">
       <div class="flex between reverse">
         <!-- Example of a sidebar. There is CSS in place to show this
              only on the homepage (based on the id).
@@ -32,13 +32,13 @@
             </div>
             <div id="langList"/>
           </div>
-          <div id="main" />        
+          <div id="main" />
           <div id="popup"/>
           <div id="versionList"/>
         </div>
       </div>
     </div>
-    <div class="container footerContainer">    
+    <div class="container footerContainer">
       <div id="footer"/>
     </div>
   </body>

--- a/data/themes/default/hypha.html
+++ b/data/themes/default/hypha.html
@@ -33,6 +33,7 @@
             <div id="langList"/>
           </div>
           <div id="main" />
+          <div id="pageEndCommands"></div>
           <div id="popup"/>
           <div id="versionList"/>
         </div>

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -540,7 +540,6 @@ class peer_reviewed_article extends Page {
 			if (self::STATUS_REVIEW === $status) {
 				$userId = $this->hyphaUser->getAttribute('id');
 				if (!$this->hasUserApproved($userId)) {
-					$commands->append($this->makeActionButton(__('art-approve'), self::PATH_APPROVE));
 					$commandsAtEnd->append($this->makeActionButton(__('art-approve'), self::PATH_APPROVE));
 				}
 			} else {

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -533,6 +533,7 @@ class peer_reviewed_article extends Page {
 
 		if (isUser()) {
 			$commands = $this->findBySelector('#pageCommands');
+			$commandsAtEnd = $this->findBySelector('#pageEndCommands');
 			$commands->append($this->makeActionButton(__('edit'), self::PATH_EDIT));
 
 			// the status change from review to approved is done automatically
@@ -540,6 +541,7 @@ class peer_reviewed_article extends Page {
 				$userId = $this->hyphaUser->getAttribute('id');
 				if (!$this->hasUserApproved($userId)) {
 					$commands->append($this->makeActionButton(__('art-approve'), self::PATH_APPROVE));
+					$commandsAtEnd->append($this->makeActionButton(__('art-approve'), self::PATH_APPROVE));
 				}
 			} else {
 				foreach ($this->statusMtx[$status] as $newStatus => $option) {
@@ -1088,6 +1090,9 @@ EOF;
 		$commands = $this->findBySelector('#pageCommands');
 		$commands->append($this->makeActionButton(__('art-cancel')));
 		$commands->append($this->makeActionButton(__('art-save'), self::PATH_EDIT, self::FORM_CMD_EDIT));
+		$commandsAtEnd = $this->findBySelector('#pageEndCommands');
+		$commandsAtEnd->append($this->makeActionButton(__('art-cancel')));
+		$commandsAtEnd->append($this->makeActionButton(__('art-save'), self::PATH_EDIT, self::FORM_CMD_EDIT));
 
 		return $this->createForm($elem, $data);
 	}

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -533,13 +533,13 @@ class peer_reviewed_article extends Page {
 
 		if (isUser()) {
 			$commands = $this->findBySelector('#pageCommands');
-			$commands->append($this->makeActionButton(__(self::PATH_EDIT), self::PATH_EDIT));
+			$commands->append($this->makeActionButton(__('edit'), self::PATH_EDIT));
 
 			// the status change from review to approved is done automatically
 			if (self::STATUS_REVIEW === $status) {
 				$userId = $this->hyphaUser->getAttribute('id');
 				if (!$this->hasUserApproved($userId)) {
-					$commands->append($this->makeActionButton(__('art-' . self::PATH_APPROVE), self::PATH_APPROVE));
+					$commands->append($this->makeActionButton(__('art-approve'), self::PATH_APPROVE));
 				}
 			} else {
 				foreach ($this->statusMtx[$status] as $newStatus => $option) {
@@ -549,7 +549,7 @@ class peer_reviewed_article extends Page {
 			}
 			if (isAdmin()) {
 				$path = $this->language . '/' . $this->pagename . '/' . self::PATH_DELETE;
-				$commands->append(makeButton(__(self::PATH_DELETE), 'if(confirm(\'' . __('sure-to-delete') . '\'))' . makeAction($path, self::FORM_CMD_DELETE, '')));
+				$commands->append(makeButton(__('delete'), 'if(confirm(\'' . __('sure-to-delete') . '\'))' . makeAction($path, self::FORM_CMD_DELETE, '')));
 			}
 		}
 

--- a/system/languages/en.php
+++ b/system/languages/en.php
@@ -8,6 +8,7 @@
 		"submit" => "submit",
 		"save" => "save",
 		"edit" => "edit",
+		"delete" => "delete",
 		"translate" => "translate",
 		"revert" => "revert",
 		"login" => "login",

--- a/system/languages/nl.php
+++ b/system/languages/nl.php
@@ -8,6 +8,7 @@
 		"submit" => "versturen",
 		"save" => "opslaan",
 		"edit" => "bewerken",
+		"delete" => "verwijderen",
 		"translate" => "vertalen",
 		"revert" => "terugdraaien",
 		"login" => "inloggen",


### PR DESCRIPTION
This adds some buttons at the end of the article view and edit pages. It also refactors some code.

These commits are copied from #149 with some minor improvements and a rebase. Not all commits are included, some will be used later for #199 instead.