### PR TITLE
Implementation of tagging system

### DIFF
--- a/data/themes/default/hypha.css
+++ b/data/themes/default/hypha.css
@@ -298,7 +298,7 @@ a.nopagelink {
  margin: 30px 0 10px;
  padding-top: 5px;
  border-top: 1px dotted #222;
- font-size: 8pt;
+ font-size: 80%;
 }
 
 #footer {

--- a/data/themes/default/hypha.css
+++ b/data/themes/default/hypha.css
@@ -292,6 +292,39 @@ a.nopagelink {
     border-top: 1px dotted grey;
 }
 
+#tagList .prefix{
+    margin-left: 10px;
+    margin-bottom: 5px;
+    font-size: 80%;
+}
+
+.selectedTags {
+    display: flex;
+}
+
+.selectedTags .delete-tag {
+    color: #8f0000;
+    cursor: pointer;
+}
+
+.remainingTags {
+    padding: 0;
+    font-size: 80%;
+}
+
+div[class^='tagSel']{
+    padding: 5px 10px;
+    margin-bottom: 5px;
+    background: var(--secondarycolor);
+    background: lightyellow;
+    margin-right: 10px;
+    color: white;
+    color: grey;
+    font-weight: bold;
+    font-size: 80%;
+    border-radius: 6px;
+}
+
 /* ---- Footer ---- */
 #footerContainer {
  padding-bottom: 2em;

--- a/data/themes/default/hypha.css
+++ b/data/themes/default/hypha.css
@@ -286,6 +286,12 @@ a.nopagelink {
  background: var(--formheaderback);
 }
 
+/* below page */
+
+.below-page{
+    border-top: 1px dotted grey;
+}
+
 /* ---- Footer ---- */
 #footerContainer {
  padding-bottom: 2em;
@@ -297,7 +303,6 @@ a.nopagelink {
  float: right;
  margin: 30px 0 10px;
  padding-top: 5px;
- border-top: 1px dotted #222;
  font-size: 80%;
 }
 

--- a/data/themes/default/hypha.css
+++ b/data/themes/default/hypha.css
@@ -559,10 +559,10 @@ input {
  max-width: 100%; }
 
 
- .prefix {
+ #langList .prefix {
  display: none; }
 
- .language {
+ #langList .language {
  display: inline-block;
  margin-right: 5px; }
 }

--- a/data/themes/default/hypha.html
+++ b/data/themes/default/hypha.html
@@ -25,7 +25,7 @@
         <div id="page">
           <div id="hyphaNotify" />
           <div id="pageCommands" />
-          <div class="flex between">
+          <div class="above-page flex between">
             <div class="pageTitle">
               <h1 id="pagename"></h1>
             </div>
@@ -34,7 +34,9 @@
           <div id="main" />
           <div id="pageEndCommands"></div>
           <div id="popup"/>
-          <div id="versionList"/>
+          <div class="below-page flex between">
+            <div id="versionList"/>
+          </div>
         </div>
       </div>
     </div>

--- a/data/themes/default/hypha.html
+++ b/data/themes/default/hypha.html
@@ -35,6 +35,7 @@
           <div id="pageEndCommands"></div>
           <div id="popup"/>
           <div class="below-page flex between">
+            <div id="tagList"/>
             <div id="versionList"/>
           </div>
         </div>

--- a/system/core/events.php
+++ b/system/core/events.php
@@ -48,8 +48,9 @@
 		cmd - php function to execute, e.g. 'save'
 		arg - argument to pass to the cmd function
 		form - the form tag to use for posting (if cmd or arg are given)
+		callback - optional callback function for making ajax calls
 	*/
-	function hypha(url, cmd, arg, form) {
+	function hypha(url, cmd, arg, form, callback = null) {
 		// update url
 		url = url.replace(/\s\//g, '/').replace(/\s$/g, '').replace(/\s/g, '_');
 
@@ -76,6 +77,11 @@
 			$form.append($arg);
 		}
 		$arg.val(arg);
+
+		if (callback) {
+			ajax(url, callback, true);
+			return;
+		}
 
 		// When there is a field with name "submit",
 		// $form.submit (and $form[0].submit) will be a

--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -141,6 +141,9 @@
 				$_type = $_node->getAttribute('type');
 				$hyphaPage = new $_type($_node, $O_O);
 
+				// add tag list to all non-system pages
+				$hyphaHtml->writeToElement('tagList', hypha_indexTags($_node, $hyphaPage->language));
+
 				// write stats
 				if (!isUser())
 					hypha_incrementStats(hypha_getLastDigestTime() + hypha_getDigestInterval());

--- a/system/core/tags.php
+++ b/system/core/tags.php
@@ -1,0 +1,195 @@
+<?php
+	// TODO:
+	// - implement error notification if new tag exists
+	// - implement tag management page: edit, translate, remove or merge tags
+	// - implement tagcontainer pagetype
+
+	function tagList(HyphaDomElement $pageListNode, $lang) {
+		/** @var HyphaDomElement $hyphaXml */
+		global $hyphaXml;
+
+		$selectedTagIds = [];
+
+		/** @var HyphaDomElement $tagEl */
+		// Build list of active tags for given page
+		foreach ($pageListNode->findXPath('tag') as $tagEl) $selectedTagIds[] = $tagEl->getAttribute('id');
+
+		$selectedTags = [];
+		$deselectedTags = [];
+
+		// Divide list of all tags stored in hypha.xml in a selected tag list and a deselected tag list
+		foreach ($hyphaXml->findXPath('hypha/tagList/tag/language[@id=' . xpath_encode($lang) . ']') as $tagLang) {
+			/** @var HyphaDomElement $tagLang */
+			$id = $tagLang->parent()->getId();
+			$tag = ['label' => $tagLang->getAttribute('label'), 'description' => $tagLang->nodeValue];
+			if (in_array($id, $selectedTagIds)) $selectedTags[$id] = $tag;
+			else $deselectedTags[$id] = $tag;
+		}
+
+		// Construct html output
+		$html = '';
+		if (!empty($selectedTagIds) || isUser()) {
+			$html.= '<span class="prefix">' . __('tags') . ': </span>';
+			$html.= '<div class="selectedTags">';
+			foreach ($selectedTags as $id => $tag) {
+				$html.= '<div class="tagSel_'.htmlspecialchars($id).'" class="tag">';
+				$html.= '<span title="'.htmlspecialchars($tag['description']).'">'.htmlspecialchars($tag['label']).'</span>';
+				if (isUser()) $html.= ' <span class="delete-tag" title="'.__('remove-tag').'" onclick="deselectTag('.htmlspecialchars(json_encode($id)).');">⨯</span>';
+				$html.= '</div>';
+			}
+			$html.= '</div>';
+			if ((isUser() && !empty($deselectedTags)) || isAdmin()) {
+				$html.= '<select class="remainingTags" onchange="selectTag(this, this.value);">';
+				$html.= '<option value="_add_" selected="selected" disabled="disabled">'.__('add').'...</option>';
+				foreach ($deselectedTags as $id => $tag) {
+					$html.= '<option id="tagRem_'.htmlspecialchars($id).'" value="'.htmlspecialchars($id).'">'.htmlspecialchars($tag['label']).'</option>';
+				}
+				if (isAdmin()) $html.= '<option value="">'.__('new').'...</option>';
+				$html.= '</select>';
+			}
+		}
+		return $html;
+	}
+
+	/*
+		Function: hypha_indexTags
+		returns list of tags for the given page
+
+		Parameters:
+		$pageListNode - DOMElement containing page settings
+		$lang - language for tag index
+	*/
+	function hypha_indexTags($pageListNode, $lang) {
+		global $hyphaHtml;
+		$formId = $hyphaHtml->getDefaultForm()->getId();
+
+		if (!$pageListNode || !$lang) return '';
+
+		$language = hypha_pageGetLanguage($pageListNode, $lang);
+		$url = $language->getAttribute('id').'/'.$language->getAttribute('name');
+
+		ob_start();
+?>
+<script>
+	function selectTag(select, id) {
+		if (!id) newTag(select);
+		else {
+			hypha(<?=json_encode($url)?>, 'tagSelect', id, document.getElementById(<?=json_encode($formId)?>), function(response) {document.getElementById('tagList').innerHTML = response;});
+			document.getElementById('tagList').innerHTML = 'loading...';
+		}
+	}
+	function deselectTag(id) {
+		hypha(<?=json_encode($url)?>, 'tagDeselect', id, document.getElementById(<?=json_encode($formId)?>), function(response) {document.getElementById('tagList').innerHTML = response;});
+		document.getElementById('tagList').innerHTML = 'loading...';
+	}
+	function newTag(select) {
+		// Revert back to initial value, so you can choose "new" again
+		select.options[0].selected = true;
+		var name = prompt(<?=json_encode(__('enter-tag-label'))?>, '');
+		if (name) {
+			var description = '';
+			while (description === '') {
+				// null when user clicks cancel
+				var description = prompt(<?=json_encode(__('enter-tag-description'))?>, '');
+			}
+
+			if (description) {
+				var json = JSON.stringify({name: name, description: description});
+				hypha(<?=json_encode($url)?>, 'tagNew', json, document.getElementById(<?=json_encode($formId)?>), function(response) {document.getElementById('tagList').innerHTML = response;});
+				document.getElementById('tagList').innerHTML = 'loading...';
+			}
+		}
+	}
+</script>
+<?php
+		$hyphaHtml->writeScript(ob_get_clean());
+
+		return tagList($pageListNode, $lang);
+	}
+
+	registerCommandCallback('tagSelect', 'tagSelectCallback');
+	registerCommandCallback('tagDeselect', 'tagDeselectCallback');
+	registerCommandCallback('tagNew', 'tagNewCallback');
+
+	function tagSelectCallback($id) {
+		global $hyphaXml;
+		global $O_O;
+
+		$lang = $O_O->getContentLanguage();
+
+		$hyphaXml->lockAndReload();
+		$pageListNode = hypha_getPage($lang, $O_O->getRequest()->getPageName());
+		$newtag = $hyphaXml->createElement('tag');
+		$newtag->setAttribute('id', $id);
+		$pageListNode->appendChild($newtag);
+		$hyphaXml->saveAndUnlock();
+
+		echo tagList($pageListNode, $lang);
+		exit;
+	}
+
+	function tagDeselectCallback($id) {
+		global $hyphaXml;
+		global $O_O;
+		$lang = $O_O->getContentLanguage();
+
+		$hyphaXml->lockAndReload();
+		$pageListNode = hypha_getPage($lang, $O_O->getRequest()->getPageName());
+		foreach($pageListNode->getElementsByTagName('tag') as $tag) if ($tag->getAttribute('id')==$id) $pageListNode->removeChild($tag);
+		$hyphaXml->saveAndUnlock();
+
+		echo tagList($pageListNode, $lang);
+		exit;
+	}
+
+	function tagNewCallback($json) {
+		global $hyphaXml;
+		global $O_O;
+
+		$hyphaXml->lockAndReload();
+
+		$lang = $O_O->getContentLanguage();
+		$pageListNode = hypha_getPage($lang, $O_O->getRequest()->getPageName());
+
+		$json = json_decode($json, true);
+
+
+		// Check if tagList exists
+		$tagList = $hyphaXml->findXPath('hypha/tagList');
+		if ($tagList->count() === 0) {
+			$tagList = $hyphaXml->createElement('tagList');
+			$hyphaXml->documentElement->appendChild($tagList);
+		}
+
+		// Check if tag exists
+		$path = 'hypha/tagList/tag/language[@id=' . xpath_encode($lang) . ' and @label=' . xpath_encode($json['name']) . ']';
+		$tagExists = $hyphaXml->findXPath($path)->count() > 0;
+
+		// Create new tag, add to tagList and page in hypha.xml
+		if (!$tagExists) {
+			$newTagName = $json['name'];
+			$newTagDescription = $json['description'];
+
+			$newTag = $hyphaXml->createElement('tag');
+			$newTag->generateId();
+			$newTagLanguage = $hyphaXml->createElement('language', $newTagDescription);
+			$newTagLanguage->setAttribute('id', $lang);
+			$newTagLanguage->setAttribute('label', $newTagName);
+			$newTag->appendChild($newTagLanguage);
+			$tagList->appendChild($newTag);
+
+			$newTagRef = $hyphaXml->createElement('tag');
+			$newTagRef->setAttribute('id', $newTag->getId());
+			$pageListNode->appendChild($newTagRef);
+
+			$hyphaXml->saveAndUnlock();
+		} else {
+			$hyphaXml->unlock();
+		}
+
+		// TODO: Replace this with a return value that lets the
+		// caller know we want to return a response (but still
+		// allow any postprocessing or other cleanup).
+		echo tagList($pageListNode, $lang);
+		exit;
+	}

--- a/system/datatypes/text.php
+++ b/system/datatypes/text.php
@@ -49,7 +49,7 @@
 		}
 
 		private function indexView(HyphaRequest $request) {
-			// setup page name and language list for the selected page
+			// setup language and tag list for the selected page
 			$this->html->writeToElement('langList', hypha_indexLanguages($this->pageListNode, $this->language));
 
 			// show content, and only allow access to previous revisions for logged in clients

--- a/system/languages/en.php
+++ b/system/languages/en.php
@@ -201,6 +201,8 @@
 		"invalid-argument" => "invalid argument",
 		"archive" => "archive",
 		"sure-to-delete" => "Are you sure you want to delete this page",
+		"enter-tag-label" => "Enter new tag (use a short word)",
+		"enter-tag-description" => "Enter short description (required)",
 		"login-to-perform-action" => "you need to be logged on in order to perform this action",
 		"page-successfully-updated" => "Page successfully updated",
 		'cannot-edit-default-theme-explanation' => 'The default theme cannot be edited. At the <a href="[[link]]">theme selection page</a>, the default theme can be copied and activated, that copy can be edited.',

--- a/system/languages/nl.php
+++ b/system/languages/nl.php
@@ -201,6 +201,8 @@
 		"invalid-argument" => "foutief argument",
 		"archive" => "archief",
 		"sure-to-delete" => "Weet je zeker dat je deze pagina wilt verwijderen",
+		"enter-tag-label" => "Voer nieuwe tag in (gebruik een kort woord)",
+		"enter-tag-description" => "Geef korte omschrijving (verplicht)",
 		"login-to-perform-action" => "je moet ingelogd zijn om deze actie te kunnen uitvoeren",
 		"page-successfully-updated" => "Pagina succesvol bijgewerkt",
 		'cannot-edit-default-theme-explanation' => 'Het standaard thema kan niet bewerkt worden. Op de <a href="[[link]]">thema keuzepagina</a>, is het mogelijk het standaard thema the kopiëren en activeren, de kopie kan wel bewerkt worden.',


### PR DESCRIPTION
Adds a tag index to a datatype similar to adding a page index. Still lacking in this implementation:
- add styling for default theme, @tammoterhark: can you take a look at this?
- implement error notification if new tag already exists in the tagList
- implement tag management page: edit, translate, remove or merge tags. Can be done (for the time being) by editing hypha.xml.
- implement tagcontainer pagetype.