### PR TITLE
Include regular CSS inside the wymeditor iframe

### DIFF
--- a/system/core/editor.php
+++ b/system/core/editor.php
@@ -155,6 +155,14 @@
 				// initiate the "site_links" plugin
 				wym.site_links();
 
+				// Set id so CSS rules apply equally inside the editor as well as outside it
+				$(wym._iframe).contents().find("body").attr('id', 'main');
+
+				// Insert the main css file into the iframe, so it mimics the final result
+				// TODO: Unhardcode
+				var hypha_css = <?= json_encode('data/themes/' . Hypha::$data->theme . '/hypha.css'); ?>;
+				$(wym._iframe).contents().find("head").append($("<link/>", { rel: "stylesheet", href: hypha_css, type: "text/css" }));
+
 				// call the update function when the form is submitted
 				let $form = $(wym.element).closest('form');
 				$form.submit(function(e) {


### PR DESCRIPTION
This makes the WYSYWIG editor a bit more accurate in terms of custom fonts, CSS
classes, etc. This currently somewhat hardcodes the path to the CSS file, which
could do with some refactoring later.

There also seems to be a specific rendering error in the version now running at http://www.dewar.nl (which has this PR applied). There, we use the `float_left` class to make images float. However, in the editor, these are rendered like this:

![image](https://user-images.githubusercontent.com/194491/54375061-a173f480-4680-11e9-9389-c777313b1dfa.png)

What seems to happen is that the `p` and `hx` tags have `position: relative`, apparently needed to get the 'Heading 4', 'Paragraph`, etc hovering texts, which makes them draw their background over the image somehow. Removing the `position: relative` fixes the image, but also breaks these hover texts.

Additionally (and only marginally related), when you hover over an image, it gets highlighted with some inline CSS. When the hover is removed, this leaves a `margin: 0px` inline CSS rather than removing the inline CSS, which subtly messes up the spacing of the image.