### PR TITLE
Use // for external content rather than http://

### DIFF
--- a/hypha.php
+++ b/hypha.php
@@ -255,7 +255,7 @@
 			$header = $xml->createElement('header', $_POST['setupTitle']);
 			$hypha->appendChild($header);
 			$footer = $xml->createElement('footer', '');
-			setNodeHtml($footer, '<a href="http://creativecommons.org/licenses/by-sa/3.0/"><img alt="Creative Commons License" style="border-width: 0pt; float: right; margin-left: 5px;" src="http://i.creativecommons.org/l/by-sa/3.0/88x31.png" /></a> This work is licensed under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>. Website powered by <a href="http://www.hypha.net">hypha</a>.');
+			setNodeHtml($footer, '<a href="http://creativecommons.org/licenses/by-sa/3.0/"><img alt="Creative Commons License" style="border-width: 0pt; float: right; margin-left: 5px;" src="https://i.creativecommons.org/l/by-sa/3.0/88x31.png" /></a> This work is licensed under a <a href="http://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>. Website powered by <a href="http://www.hypha.net">hypha</a>.');
 			$hypha->appendChild($footer);
 			$menu = $xml->createElement('menu', '');
 			setNodeHtml($menu, '<a href="hypha:'.$id.'"/>');

--- a/index.php
+++ b/index.php
@@ -80,7 +80,7 @@
 	$hyphaHtml = new HTMLDocument(Hypha::$data->html, $hyphaUrl);
 	$pathToTheme = 'data/themes/' . Hypha::$data->theme;
 	$hyphaHtml->linkStyle($pathToTheme . '/hypha.css');
-	$hyphaHtml->linkScript('http://code.jquery.com/jquery-1.7.1.min.js');
+	$hyphaHtml->linkScript('//code.jquery.com/jquery-1.7.1.min.js');
 	$hyphaHtml->linkScript('system/help/help.js');
 	$hyphaHtml->setTitle(hypha_getTitle());
 	$hyphaHtml->writeToElement('header', hypha_getHeader());


### PR DESCRIPTION
This fixes mixed content errors when running on HTTPS. In particular,
this prevents jquery from being blocked and breaking significant
content.

Note that this also changes the default footer content as well. Existing
instances of Hypha will continue to use their original footer, which
might still contain an http image link that needs to be changed
manually.