### PR TITLE
Fix PHP5: Remove return type declarations from php-dom-wrapper

### DIFF
--- a/system/php-dom-wrapper/Traits/ManipulationTrait.php
+++ b/system/php-dom-wrapper/Traits/ManipulationTrait.php
@@ -291,7 +291,7 @@ trait ManipulationTrait
      *
      * @return self
      */
-    public function prependTo($selector): self {
+    public function prependTo($selector) {
         if ($selector instanceof \DOMNode || $selector instanceof NodeList) {
             $nodes = $this->inputAsNodeList($selector);
         } else {
@@ -306,7 +306,7 @@ trait ManipulationTrait
      *
      * @return self
      */
-    public function appendTo($selector): self {
+    public function appendTo($selector) {
         if ($selector instanceof \DOMNode || $selector instanceof NodeList) {
             $nodes = $this->inputAsNodeList($selector);
         } else {
@@ -716,7 +716,7 @@ trait ManipulationTrait
      *
      * @return NodeList
      */
-    public function create($input): NodeList {
+    public function create($input) {
         return $this->inputAsNodeList($input);
     }
 


### PR DESCRIPTION
These were added in commit 407c83a (Backport php-dom-wrapper's create,
appendTo and prependTo methods), unintentionally raising the minimum PHP
version to 7.0. By removing these return type declarations, the code
should be compatible with PHP 5 again.