### PR TITLE
peer_reviewed_article: Fix getStatus for new articles

### DIFF
--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -1489,9 +1489,13 @@ EOF;
 	 */
 	private function getStatus() {
 		/** @var HyphaDomElement $article */
-		$article = $this->xml->find(self::FIELD_NAME_ARTICLE);
-		$status = $article->getAttribute(self::FIELD_NAME_STATUS);
-		if ('' == $status) {
+		$article = $this->xml->find(self::FIELD_NAME_ARTICLE)->first();
+		if ($article instanceof HyphaDomElement) {
+			$status = $article->getAttribute(self::FIELD_NAME_STATUS);
+			if ('' == $status) {
+				$status = self::STATUS_NEWLY_CREATED;
+			}
+		} else {
 			$status = self::STATUS_NEWLY_CREATED;
 		}
 


### PR DESCRIPTION
When a new article is created, it has no "article" element yet. When
getStatus() was then called (e.g. by ensureStructure()), this would
result in an empty NodeList in $article, and calling getAttribute() on
that would throw an exception.

This was broken in commit 06584a6 (peer_reviewed_article: clean up)
which replaced getAttr() with getAttribute(). While getAttribute() on a
NodeList simply calls that method on the first element in the list (and
throws an exception if there is none), the getAttr() method behaves
slightly different: It return null if there is no first element (or if
the attribute is empty), so that used to work for new articles.

This fixes this by explicitly calling the first() method on the
NodeList, which returns the actual HyphaDomElement or null, and then
handles the null case separately.