### PR TITLE
Make file write operations more robust

### DIFF
--- a/system/core/database.php
+++ b/system/core/database.php
@@ -599,6 +599,13 @@
 		function lock() {
 			if ($this->fd)
 				throw new LogicException('Cannot lock file ' . $this->filename . ', already locked');
+
+			// Clear the last error, to prevent using an
+			// older error when something goes wrong without
+			// generating a PHP error (e.g. like read/write
+			// before PHP 7.4).
+			error_clear_last();
+
 			$this->fd = fopen($this->filename, 'c+');
 			if ($this->fd === false)
 				throw new RuntimeException('Cannot lock file ' . $this->filename . ', open failed: ' . error_get_last()['message']);

--- a/system/core/database.php
+++ b/system/core/database.php
@@ -602,7 +602,11 @@
 			$this->fd = fopen($this->filename, 'c+');
 			if ($this->fd === false)
 				throw new RuntimeException('Cannot lock file ' . $this->filename . ', open failed: ' . error_get_last()['message']);
-			flock($this->fd, LOCK_EX);
+			if (!flock($this->fd, LOCK_EX)) {
+				fclose($this->fd);
+				$this->fd = false;
+				throw new RuntimeException('Cannot lock file ' . $this->filename . ', lock failed: ' . error_get_last()['message']);
+			}
 		}
 
 

--- a/system/core/database.php
+++ b/system/core/database.php
@@ -633,6 +633,7 @@
 			}
 
 			$contents = stream_get_contents($fd);
+			$contents = stream_get_contents($fd, /* maxlength */ -1, /* offset */ 0);
 
 			if (!$this->fd)
 				fclose($fd);

--- a/system/core/database.php
+++ b/system/core/database.php
@@ -921,14 +921,14 @@
 			do {
 				$image = new HyphaImage(uniqid() . '.' . $extension);
 				$filename = $image->getPath();
-				$fd = @fopen($filename, 'x');
+				$fileHandle = @fopen($filename, 'x');
 				// If fopen failed, but the file does
 				// not exist, error out (to prevent
 				// looping infinitely)
-				if ($fd === false && !file_exists($filename))
+				if ($fileHandle === false && !file_exists($filename))
 					return __('failed-to-process-image') . error_get_last();
-			} while ($fd === false);
-			fclose($fd);
+			} while ($fileHandle === false);
+			fclose($fileHandle);
 
 			move_uploaded_file($fileinfo['tmp_name'], $filename);
 			return $image;

--- a/system/core/database.php
+++ b/system/core/database.php
@@ -659,17 +659,9 @@
 			Write the given string to the file, replacing any
 			current contents.
 
-			If the file is not opened yet, it is opened and
-			an exclusive lock is taken. After writing, the
-			file is closed and the lock is released.
-
-			If the file was already opened (and thus an
-			exclusive lock is held), the file is not closed
-			after writing, and the lock remains in effect.
-
-			This method can essentially be used just like
-			file_put_contents(), but with locking enabled by
-			default.
+			The file must be already locked before calling
+			this. It is not closed or unlocked after
+			writing.
 		*/
 		function write($content) {
 			if (!$this->fd)


### PR DESCRIPTION
This changes file writes to go through a temporary file, which prevents data corruption when the write itself fails (e.g. due to disk full).