### PR TITLE
Tag index page

### DIFF
--- a/data/themes/default/hypha.css
+++ b/data/themes/default/hypha.css
@@ -995,3 +995,30 @@ body.type_peer_reviewed_article .input-wrapper.field_type_editor:not(.field_name
     content: " *";
     color: #b90;
 }
+
+.tagindex {
+    list-style-type: none;
+    padding-left: 0;
+}
+
+.tagindex-item {
+    border-bottom: 1px black solid;
+}
+
+.tagindex-item:last-child {
+    border-bottom: none;
+}
+
+.tagindex-item h2 {
+    margin: 0;
+}
+
+.tagindex-item.is-private h2:after {
+    content: " *";
+    color: #b90;
+}
+
+.tagindex-item > a {
+    text-decoration: none;
+    color: inherit;
+}

--- a/system/core/HyphaRequest.php
+++ b/system/core/HyphaRequest.php
@@ -14,6 +14,7 @@
 		const HYPHA_SYSTEM_PAGE_IMAGES = 'images';
 		const HYPHA_SYSTEM_PAGE_INDEX = 'index';
 		const HYPHA_SYSTEM_PAGE_SETTINGS = 'settings';
+		const HYPHA_SYSTEM_PAGE_TAG_INDEX = 'tag';
 		const HYPHA_SYSTEM_PAGE_UPLOAD = 'upload';
 		const HYPHA_SYSTEM_PAGE_CHOOSER = 'chooser';
 		const HYPHA_SYSTEM_PAGE_HELP = 'help';
@@ -118,6 +119,7 @@
 				HyphaRequest::HYPHA_SYSTEM_PAGE_FILES,
 				HyphaRequest::HYPHA_SYSTEM_PAGE_IMAGES,
 				HyphaRequest::HYPHA_SYSTEM_PAGE_INDEX,
+				HyphaRequest::HYPHA_SYSTEM_PAGE_TAG_INDEX,
 				HyphaRequest::HYPHA_SYSTEM_PAGE_SETTINGS,
 				HyphaRequest::HYPHA_SYSTEM_PAGE_UPLOAD,
 				HyphaRequest::HYPHA_SYSTEM_PAGE_CHOOSER,

--- a/system/core/base.php
+++ b/system/core/base.php
@@ -897,10 +897,9 @@
 				}
 			}
 
-			// add all non-system datatypes to $hyphaDatatypes
-			$systemDatatypes = [settingspage::class];
+			// add all datatypes to $hyphaDatatypes
 			foreach (array_slice(get_declared_classes(), $pageTypeIndex) as $class) {
-				if (!in_array($class, $systemDatatypes) && in_array(Page::class, class_parents($class)) && (new \ReflectionClass($class))->isInstantiable()) {
+				if (in_array(HyphaDatatypePage::class, class_parents($class)) && (new \ReflectionClass($class))->isInstantiable()) {
 					$hyphaDatatypes[$class] = call_user_func($class . '::getDatatypeName');
 				}
 			}

--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -92,6 +92,17 @@
 			return showPagename($this->pagename);
 		}
 
+		public function renderSingleLine(HyphaDomElement $container) {
+			$h2 = $container->document()->createElement('h2');
+			$h2->setText($this->getTitle());
+			$h2->appendTo($container);
+		}
+
+		public function renderExcerpt(HyphaDomElement $container) {
+			// Default to just the single line version
+			$this->renderSingleLine($container);
+		}
+
 		/*
 		 * Returns a date typically used for sorting these pages
 		 * (i.e. the publish date or last update date).

--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -81,6 +81,15 @@
 			$this->language = $language->getAttribute('id');
 			$this->pagename = $language->getAttribute('name');
 		}
+
+		/*
+		 * Returns a date typically used for sorting these pages
+		 * (i.e. the publish date or last update date).
+		 *
+		 * Returns a DateTime object or null if no timestamp is
+		 * available.
+		 */
+		abstract public function getSortDateTime();
 	}
 
 	/*

--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -181,6 +181,21 @@ EOF;
 	}
 
 	/*
+		Function: createPageInstance
+		Creates a page object (appropriate subclass of
+		HyphaDatatypePage, e.g. textpage) instance from the
+		given page node.
+
+		Parameters:
+		RequestContext $O_O
+		HyphaDomElement $node - The page node from $hyphaXml
+	*/
+	function createPageInstance(RequestContext $O_O, HyphaDomElement $node) {
+		$type = $node->getAttribute('type');
+		return new $type($node, $O_O);
+	}
+
+	/*
 		Function: loadPage
 		loads all html needed for page pagename/view
 
@@ -207,8 +222,7 @@ EOF;
 
 			$isPrivate = $_node && in_array($_node->getAttribute('private'), ['true', '1', 'on']);
 			if ($_node && (!$isPrivate || isUser())) {
-				$_type = $_node->getAttribute('type');
-				$hyphaPage = new $_type($_node, $O_O);
+				$hyphaPage = createPageInstance($O_O, $_node);
 
 				// add tag list to all non-system pages
 				$hyphaHtml->writeToElement('tagList', hypha_indexTags($_node, $hyphaPage->language));

--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -305,6 +305,9 @@ EOF;
 						break;
 				}
 				break;
+			case HyphaRequest::HYPHA_SYSTEM_PAGE_TAG_INDEX:
+				$hyphaPage = new tagindexpage($O_O);
+				break;
 			case HyphaRequest::HYPHA_SYSTEM_PAGE_HELP:
 				$subject = isset($args[0]) ? urldecode($args[0]) : 'undefined';
 				$helpLanguage = isset($args[1]) ? $args[1] : $O_O->getInterfaceLanguage();

--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -4,23 +4,54 @@
 	/*
 		Title: Pages
 
-		This chapter describes the way pages are registered.
+		This chapter describes the way views and pages are registered.
 	*/
 
 	/*
-		Class: Page
-		abstract class for handling a certain kind of data
+		Class: HyphaPage
+		abstract class for a page that can process a request.
 	*/
-	abstract class Page {
-		public $pageListNode, $html, $language, $pagename, $O_O, $args, $privateFlag;
-		function __construct($node, RequestContext $O_O) {
+	abstract class HyphaPage {
+		public $html, $language, $pagename, $O_O, $args, $privateFlag;
+
+		function __construct(RequestContext $O_O) {
 			global $hyphaHtml;
 			$this->html = $hyphaHtml;
 			$this->O_O = $O_O;
 			// TODO: Remove args (and let subclasses talk to the request instead)
 			$this->args = $O_O->getRequest()->getArgs();
-			if ($node)
-				$this->replacePageListNode($node);
+		}
+
+		/**
+		 * Return the given url argument, or null if it is not
+		 * present.
+		 */
+		protected function getArg($index) {
+			if (array_key_exists($index, $this->args))
+				return $this->args[$index];
+			return null;
+		}
+
+		abstract function process(HyphaRequest $request);
+	}
+
+	/*
+		Class: HyphaSystemPage
+		abstract class for a system page that has no backing datatype.
+	*/
+	abstract class HyphaSystemPage extends HyphaPage {
+	}
+
+	/*
+		Class: HyphaDatatypePage
+		abstract class for a page backed by datatype and xml file.
+	*/
+	abstract class HyphaDatatypePage extends HyphaPage {
+		public $pageListNode, $language, $pagename, $privateFlag;
+
+		function __construct($node, RequestContext $O_O) {
+			parent::__construct($O_O);
+			$this->replacePageListNode($node);
 		}
 
 		public static function getDatatypeName() {
@@ -50,18 +81,6 @@
 			$this->language = $language->getAttribute('id');
 			$this->pagename = $language->getAttribute('name');
 		}
-
-		/**
-		 * Return the given url argument, or null if it is not
-		 * present.
-		 */
-		protected function getArg($index) {
-			if (array_key_exists($index, $this->args))
-				return $this->args[$index];
-			return null;
-		}
-
-		abstract function process(HyphaRequest $request);
 	}
 
 	/*

--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -83,6 +83,16 @@
 		}
 
 		/*
+		 * Returns the title to be used for e.g. linking to this
+		 * page.
+		 */
+		public function getTitle() {
+			// TODO: Implement a meaningful title in all
+			// subclasses and make this function abstract?
+			return showPagename($this->pagename);
+		}
+
+		/*
 		 * Returns a date typically used for sorting these pages
 		 * (i.e. the publish date or last update date).
 		 *

--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -49,7 +49,7 @@
 	abstract class HyphaDatatypePage extends HyphaPage {
 		public $pageListNode, $language, $pagename, $privateFlag;
 
-		function __construct($node, RequestContext $O_O) {
+		function __construct(HyphaDomElement $node, RequestContext $O_O) {
 			parent::__construct($O_O);
 			$this->replacePageListNode($node);
 		}
@@ -73,7 +73,7 @@
 			writeToDigest($hyphaUser->getAttribute('fullname').__('deleted-page').$this->language.'/'.$this->pagename, 'page delete');
 		}
 
-		protected function replacePageListNode($node) {
+		protected function replacePageListNode(HyphaDomElement $node) {
 			global $O_O;
 			$this->pageListNode = $node;
 			$this->privateFlag = in_array($node->getAttribute('private'), ['true', '1', 'on']);

--- a/system/core/tags.php
+++ b/system/core/tags.php
@@ -77,7 +77,7 @@
 		foreach ($hyphaXml->findXPath('hypha/tagList/tag/language[@id=' . xpath_encode($lang) . ']') as $tagLang) {
 			/** @var HyphaDomElement $tagLang */
 			$id = $tagLang->parent()->getId();
-			$tag = ['label' => $tagLang->getAttribute('label'), 'description' => $tagLang->nodeValue];
+			$tag = ['label' => $tagLang->getAttribute('label'), 'description' => $tagLang->nodeValue, 'lang' => $tagLang->getAttribute('id')];
 			if (in_array($id, $selectedTagIds)) $selectedTags[$id] = $tag;
 			else $deselectedTags[$id] = $tag;
 		}
@@ -91,7 +91,11 @@
 			$html.= '<div class="selectedTags">';
 			foreach ($selectedTags as $id => $tag) {
 				$html.= '<div class="tagSel_'.htmlspecialchars($id).'" class="tag">';
+
+				$tag_index_url = HyphaRequest::HYPHA_SYSTEM_PAGE_TAG_INDEX . '/' . $tag['lang'] . '/' . $tag['label'];
+				$html.= '<a href="'.htmlspecialchars($tag_index_url).'">';
 				$html.= '<span title="'.htmlspecialchars($tag['description']).'">'.htmlspecialchars($tag['label']).'</span>';
+				$html.= '</a>';
 				if (isUser()) $html.= ' <span class="delete-tag" title="'.__('remove-tag').'" onclick="deselectTag('.htmlspecialchars(json_encode($id)).');">⨯</span>';
 				$html.= '</div>';
 			}

--- a/system/core/tags.php
+++ b/system/core/tags.php
@@ -3,6 +3,26 @@
 	// - implement error notification if new tag exists
 	// - implement tag management page: edit, translate, remove or merge tags
 	// - implement tagcontainer pagetype
+	class HyphaTags {
+		static function findTagByLabel($lang, $label) {
+			/** @var HyphaDomElement $hyphaXml */
+			global $hyphaXml;
+			$path = 'hypha/tagList/tag/language[@id=' . xpath_encode($lang) . ' and @label=' . xpath_encode($label) . ']';
+			$node = $hyphaXml->findXPath($path)->parent()->first();
+			return ($node ? new HyphaTag($node) : null);
+		}
+	}
+
+	class HyphaTag {
+		private $node;
+		function __construct(HyphaDomElement $node) {
+			$this->node = $node;
+		}
+
+		function getId() {
+			return $this->node->getId();
+		}
+	}
 
 	function tagList(HyphaDomElement $pageListNode, $lang) {
 		/** @var HyphaDomElement $hyphaXml */

--- a/system/core/tags.php
+++ b/system/core/tags.php
@@ -11,6 +11,42 @@
 			$node = $hyphaXml->findXPath($path)->parent()->first();
 			return ($node ? new HyphaTag($node) : null);
 		}
+
+		static function findPagesWithTags(HyphaTag $tag, array $pageTypes=[], bool $includePrivate=false, $skip=0, $limit=0) {
+			/** @var HyphaDomElement $hyphaXml */
+			global $hyphaXml;
+
+			$pageFilters = '';
+			if ($pageTypes) {
+				$filterFunc = function($type) { return "@type=" . xpath_encode($type); };
+				$attrFilters = array_map($filterFunc, $pageTypes);
+				$pageFilters .= "[" . implode(" or ", $attrFilters) . "]";
+			}
+			if ($includePrivate !== true) {
+				$pageFilters .= "[@private='off']";
+			}
+
+			// TODO: skip and limit might not be useful
+			// without sorting, but xpath 1.0 does not seem
+			// to support sorting.
+			$positionFilters = '';
+			if ($skip > 0) {
+				// Note: position() is 1-based
+				$positionFilters .= '[position() >= ' . ($skip + 1) . ']';
+			}
+			if ($limit > 0) {
+				// This refers to the position *after*
+				// applying skip, because it is in a
+				// different [] predicate block.
+				$positionFilters .= '[position() < ' . ($limit + 1) . ']';
+			}
+
+			$tagFilter = '@id=' . xpath_encode($tag->getId());
+			$xpath = "hypha/pageList/page${pageFilters}[child::tag[${tagFilter}]]${positionFilters}";
+			$pages = $hyphaXml->findXPath($xpath);
+
+			return $pages;
+		}
 	}
 
 	class HyphaTag {

--- a/system/datatypes/festival.php
+++ b/system/datatypes/festival.php
@@ -9,7 +9,7 @@
 /*
 	Class: festivalpage
 */
-	class festivalpage extends Page {
+	class festivalpage extends HyphaDatatypePage {
 		public function __construct($pageListNode, RequestContext $O_O) {
 			parent::__construct($pageListNode, $O_O);
 			$this->xml = new Xml('festival', Xml::multiLingualOn, Xml::versionsOff);

--- a/system/datatypes/festival.php
+++ b/system/datatypes/festival.php
@@ -97,6 +97,11 @@
 			}
 		}
 
+		public function getSortDateTime() {
+			// TODO: What to return here?
+			return null;
+		}
+
 		/**
 		 * Retrieve a config value from the XML. This finds a
 		 * tag with the given id, and retrieves the given

--- a/system/datatypes/mailinglist.php
+++ b/system/datatypes/mailinglist.php
@@ -12,7 +12,7 @@ use DOMWrap\NodeList;
  * Class: mailinglist
  */
 
-class mailinglist extends Page {
+class mailinglist extends HyphaDatatypePage {
 	/** @var Xml */
 	private $xml;
 

--- a/system/datatypes/mailinglist.php
+++ b/system/datatypes/mailinglist.php
@@ -125,6 +125,11 @@ class mailinglist extends HyphaDatatypePage {
 		return '404';
 	}
 
+	public function getSortDateTime() {
+		// TODO: Return last mailing sent date?
+		return null;
+	}
+
 	/**
 	 * Checks if the status is new and if so builds the structure and sets the status to draft.
 	 */

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -13,7 +13,7 @@ use DOMWrap\NodeList;
  */
 
 // TODO [LRM]: add version control on peer_reviewed_article
-class peer_reviewed_article extends Page {
+class peer_reviewed_article extends HyphaDatatypePage {
 	/** @var Xml */
 	private $xml;
 

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -1488,7 +1488,7 @@ EOF;
 	 *
 	 * @return string
 	 */
-	private function getTitle() {
+	public function getTitle() {
 		$title = $this->xml->find(self::FIELD_NAME_TITLE);
 		if ($title instanceof NodeList) {
 			$title = $title->getText();

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -249,9 +249,6 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		/** @var HyphaDomElement $content */
 		$content = $this->xml->find(self::FIELD_NAME_CONTENT);
 
-		$author = $article->getAttribute(self::FIELD_NAME_AUTHOR);
-		$publishedTimestamp = ltrim($article->getAttribute(self::FIELD_NAME_PUBLISHED_AT), 't');
-
 		/** @var HyphaDomElement $main */
 		$main = $this->html->find('#main');
 
@@ -288,25 +285,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		// Facebook
 		$shareDiv->append('<a href="https://www.facebook.com/sharer/sharer.php?u='.rawurlencode($linkToPage).'" target="_blank"><div class="facebook-link"></div></a>');
 
-		if ($author) {
-			$main->append('<div class="author">' . __('art-by') . ' ' . htmlspecialchars($author) . '</div>');
-		}
-		if ($publishedTimestamp) {
-			/** @var HyphaDomElement $publish */
-			$publish = $this->html->createElement('div');
-			$publish->setAttribute('class', 'published_at');
-			/** @var HyphaDomElement $publishDate */
-			$publishDate = $this->html->createElement('span');
-			$publishDate->setAttribute('class', 'date');
-			$publishDate->text(strftime(__('art-date-format-date'), $publishedTimestamp));
-			$publish->append($publishDate);
-			/** @var HyphaDomElement $publishTime */
-			$publishTime = $this->html->createElement('span');
-			$publishTime->setAttribute('class', 'time');
-			$publishTime->text(strftime(__('art-date-format-time'), $publishedTimestamp));
-			$publish->append($publishTime);
-			$main->append($publish);
-		}
+		$this->appendAuthorAndTimestamp($main, $article);
 
 		if (isUser()) {
 			$excerpt = $this->xml->find(self::FIELD_NAME_EXCERPT)->children();
@@ -357,6 +336,38 @@ class peer_reviewed_article extends HyphaDatatypePage {
 
 		return null;
 	}
+
+	public function appendAuthorAndTimestamp($container, $article) {
+		$doc = $container->document();
+
+		$author = $article->getAttribute(self::FIELD_NAME_AUTHOR);
+		$publishedTimestamp = ltrim($article->getAttribute(self::FIELD_NAME_PUBLISHED_AT), 't');
+
+		if ($author) {
+			$author_div = $doc->createElement('div');
+			$author_div->addClass('author');
+			$author_div->setText(__('art-by') . ' ' . $author);
+			$container->append($author_div);
+		}
+		if ($publishedTimestamp) {
+			/** @var HyphaDomElement $publish */
+			$publish_div = $doc->createElement('div');
+			$publish_div->setAttribute('class', 'published_at');
+			/** @var HyphaDomElement $publishDate */
+			$publishDate = $doc->createElement('span');
+			$publishDate->setAttribute('class', 'date');
+			$publishDate->text(strftime(__('art-date-format-date'), $publishedTimestamp));
+			$publish_div->append($publishDate);
+			/** @var HyphaDomElement $publishTime */
+			$publishTime = $doc->createElement('span');
+			$publishTime->setAttribute('class', 'time');
+			$publishTime->text(strftime(__('art-date-format-time'), $publishedTimestamp));
+			$publish_div->append($publishTime);
+			$container->append($publish_div);
+		}
+	}
+
+
 
 	/**
 	 * Deletes the article.

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -148,6 +148,19 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		return new DateTime("@" . $timestamp);
 	}
 
+	public function renderExcerpt($container) {
+		$doc = $container->document();
+		$h2 = $doc->createElement('h2')->setText($this->getTitle());
+		$h2->appendTo($container);
+
+		$article = $this->xml->find(self::FIELD_NAME_ARTICLE);
+		$this->appendAuthorAndTimestamp($container, $article);
+		$excerpt_div = $doc->createElement('div');
+		$excerpt_div->addClass('excerpt');
+		$excerpt_div->append($this->getExcerpt());
+		$excerpt_div->appendTo($container);
+	}
+
 	/**
 	 * Checks if the status is new and if so builds the structure and sets the status to draft.
 	 */
@@ -1509,6 +1522,15 @@ EOF;
 		}
 
 		return $title;
+	}
+
+	/**
+	 * Gets the article excerpt.
+	 *
+	 * @return NodeList
+	 */
+	public function getExcerpt() {
+		return $this->xml->find(self::FIELD_NAME_EXCERPT);
 	}
 
 	/**

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -139,6 +139,15 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		return '404';
 	}
 
+	public function getSortDateTime() {
+		$article = $this->xml->find(self::FIELD_NAME_ARTICLE);
+		$value = $article->getAttribute(self::FIELD_NAME_PUBLISHED_AT);
+		if (!$value)
+			$value = $article->getAttribute(self::FIELD_NAME_UPDATED_AT);
+		$timestamp = ltrim($value, "t");
+		return new DateTime("@" . $timestamp);
+	}
+
 	/**
 	 * Checks if the status is new and if so builds the structure and sets the status to draft.
 	 */

--- a/system/datatypes/settings.php
+++ b/system/datatypes/settings.php
@@ -6,9 +6,9 @@
 	See Also:
 	<Page>
 */
-	class settingspage extends Page {
+	class settingspage extends HyphaSystemPage {
 		function __construct(RequestContext $O_O) {
-			parent::__construct('', $O_O);
+			parent::__construct($O_O);
 			registerCommandCallback('settingsInvite', Array($this, 'invite'));
 			registerCommandCallback('settingsRemind', Array($this, 'remindNewUser'));
 			registerCommandCallback('settingsRegister', Array($this, 'register'));

--- a/system/datatypes/tagindex.php
+++ b/system/datatypes/tagindex.php
@@ -14,7 +14,9 @@
 
 		public function tagIndexView(HyphaRequest $request) {
 			$lang = $request->getArg(0);
-			$label = $request->getArg(1);
+			// TODO: This urldecode should really be done by
+			// HyphaRequest (#274)
+			$label = urldecode($request->getArg(1));
 
 			$tag = HyphaTags::findTagByLabel($lang, $label);
 			if ($tag === null)

--- a/system/datatypes/tagindex.php
+++ b/system/datatypes/tagindex.php
@@ -1,0 +1,91 @@
+<?php
+/*
+	Class: tagindexpage
+	Shows an index page for articles based on their tags
+*/
+	class tagindexpage extends HyphaSystemPage {
+		function __construct(RequestContext $O_O) {
+			parent::__construct($O_O);
+		}
+
+		public function process(HyphaRequest $request) {
+			return $this->tagIndexView($request);
+		}
+
+		public function tagIndexView(HyphaRequest $request) {
+			$lang = $request->getArg(0);
+			$label = $request->getArg(1);
+
+			$tag = HyphaTags::findTagByLabel($lang, $label);
+			if ($tag === null)
+				return '404';
+
+			/** @var HyphaDomElement $main */
+			$main = $this->html->find('#main');
+
+			/** @var HyphaDomElement $pagename */
+			$pagename = $this->html->find('#pagename');
+			$tagprefixSpan = $this->html->createElement('span');
+			$tagprefixSpan->setText('Index for tag: ');
+			$tagprefixSpan->setAttribute('class', 'tag_prefix');
+			$tagSpan = $this->html->createElement('span');
+			$tagSpan->setAttribute('class', 'selected_tag');
+			$tagSpan->setText($label);
+			$pagename->append($tagprefixSpan);
+			$pagename->append($tagSpan);
+
+			$includePrivate = isUser();
+			$pages = $this->getPages($tag, $includePrivate);
+			$pages = $this->sortPages($pages);
+
+			$pagesList = $this->renderPages($pages);
+			$main->append($pagesList);
+		}
+
+		private function sortPages($pages) {
+			// TODO: This should cache sort dates
+			$compare = function($a, $b) {
+				$aDate = $a->getSortDateTime();
+				$bDate = $b->getSortDateTime();
+				// TODO Can we better handle null here?
+				return ($bDate ? $bDate->getTimestamp() : 0) - ($aDate ? $aDate->getTimestamp() : 0);
+			};
+			usort($pages, $compare);
+			return $pages;
+		}
+
+		private function getPages(HyphaTag $tag, $includePrivate = false) {
+			$pageTypes = []; // All pagetypes
+			$pageNodes = HyphaTags::findPagesWithTags($tag, $pageTypes, $includePrivate);
+			$pages = [];
+			foreach ($pageNodes as $node) {
+				$pages[] = createPageInstance($this->O_O, $node);
+			}
+			return $pages;
+		}
+
+		private function renderPages($pages) {
+			/** @var HyphaDomElement $ul */
+			$ul = $this->html->createElement('ul');
+			$ul->addClass('tagindex');
+			foreach ($pages as $page) {
+				$li = $this->renderPage($page);
+				$ul->append($li);
+			}
+			return $ul;
+		}
+
+		private function renderPage(HyphaDatatypePage $page) {
+			$li = $this->html->createElement('li');
+			$li->addClass('tagindex-item');
+			$li->addClass('type_' . get_class($page));
+			$li->addClass($page->privateFlag ? 'is-private' : 'is-public');
+
+			$a = $this->html->createElement('a')->appendTo($li);
+			$a->setAttribute('href', $page->language.'/'.$page->pagename);
+
+			$page->renderExcerpt($a);
+
+			return $li;
+		}
+	}

--- a/system/datatypes/text.php
+++ b/system/datatypes/text.php
@@ -6,7 +6,7 @@
 	See Also:
 	<Page>
 */
-	class textpage extends Page {
+	class textpage extends HyphaDatatypePage {
 		/** @var Xml */
 		public $xml;
 

--- a/system/datatypes/text.php
+++ b/system/datatypes/text.php
@@ -47,6 +47,12 @@
 			return '404';
 		}
 
+		public function getSortDateTime() {
+			$version = getCurrentVersionNode($this->xml);
+			$timestamp = ltrim($version->getId(), "t");
+			return new DateTime("@" . $timestamp);
+		}
+
 		private function defaultView(HyphaRequest $request) {
 			// setup language and tag list for the selected page
 			$this->html->writeToElement('langList', hypha_indexLanguages($this->pageListNode, $this->language));


### PR DESCRIPTION
This implements a minimal tag index page (i.e. #298). It is a system page, which shows all pages (not just articles) tagged with a given tag. These index pages can be reached by clicking a tag on an article.