### PR TITLE
Fix language selection in index

### DIFF
--- a/system/core/base.php
+++ b/system/core/base.php
@@ -824,57 +824,6 @@
 		return $index;
 	}
 
-	/*
-		Function: hypha_indexPages
-		returns alphabetical overview of all pages in the given language
-
-		Parameters:
-		$language
-	*/
-	function hypha_indexPages($language) {
-		// get list of available pages and sort alphabetically
-		foreach(hypha_getPageList() as $page) {
-			$lang = hypha_pageGetLanguage($page, $language);
-			if ($lang) if (isUser() || ($page->getAttribute('private')!='on')) {
-				$pageList[] = $lang->getAttribute('name').($page->getAttribute('private')=='on' ? '&#;' : '');
-				$pageListDatatype[$lang->getAttribute('name')] = $page->getAttribute('type');
-			}
-		}
-		if ($pageList) array_multisort(array_map('strtolower', $pageList), $pageList);
-
-		// add capitals
-		$capital = 'A';
-		$first = true;
-		if ($pageList) foreach($pageList as $pagename) {
-			while($capital < strtoupper($pagename[0])) $capital++;
-			if (strtoupper($pagename[0]) == $capital) {
-				if (!$first) {
-					$htmlList[] = '</div>';
-				}
-				$htmlList[] = '<div class="letter-wrapper">';
-				$htmlList[] = '<div class="letter">'.$capital.'</div>';
-				$capital++;
-				$first = false;
-			}
-			$privatePos = strpos($pagename, '&#;');
-			if ($privatePos) $pagename = substr($pagename, 0, $privatePos);
-			$htmlList[] = '<div class="index-item type_'.$pageListDatatype[$pagename].' '.($privatePos ? 'is-private' : 'is-public').'"><a href="'.$language.'/'.$pagename.'">'.showPagename($pagename).'</a></div>';
-		}
-
-		$html = '<div class="index">';
-		foreach($htmlList as $htmlLine) $html.= $htmlLine;
-		$html.= '</div>';
-		return $html;
-	}
-
-	function hypha_indexImages() {
-		return 'image index is not yet implemented';
-	}
-
-	function hypha_indexFiles() {
-		return 'file index is not yet implemented';
-	}
-
 	function hypha_substitute($string, array $vars) {
 		foreach ($vars as $key => $val) $string = str_replace('[[' . $key . ']]', $val, $string);
 		return $string;

--- a/system/core/base.php
+++ b/system/core/base.php
@@ -817,7 +817,7 @@
 			if ($lang == $language) $index.= '<span class="language selected">'.$lang.'</span>';
 			elseif (!$page || array_key_exists($lang, $pageLangList)) {
 				if ($page) $index.= '<span class="language"><a href="'.$lang.'/'.$pageLangList[$lang].'">'.$lang.'</a></span>';
-				else $index.= '<span class="language"><a href="'.$lang.'/index">'.$lang.'</a></span>';
+				else $index.= '<span class="language"><a href="index/'.$lang.'">'.$lang.'</a></span>';
 			}
 			else $index.= '<span class="language disabled">'.$lang.'</span>';
 		}

--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -297,13 +297,7 @@ EOF;
 				echo hypha_searchHelp($O_O, $subject, $helpLanguage);
 				exit;
 			case HyphaRequest::HYPHA_SYSTEM_PAGE_SETTINGS:
-				if (isUser() || $args[0]=='register') {
-					$hyphaPage = new settingspage($O_O);
-				}
-				else {
-					header('Location: '.$hyphaUrl.hypha_getDefaultLanguage().'/'.hypha_getDefaultPage());
-					exit;
-				}
+				$hyphaPage = new settingspage($O_O);
 				break;
 			case HyphaRequest::HYPHA_SYSTEM_PAGE_UPLOAD:
 				if ($args[0]=='image') {

--- a/system/core/pages.php
+++ b/system/core/pages.php
@@ -237,7 +237,6 @@ EOF;
 	*/
 	function loadPage(RequestContext $O_O) {
 		global $hyphaHtml, $hyphaPage, $hyphaUrl;
-		$isoLangList = Language::getIsoList();
 
 		$request = $O_O->getRequest();
 		$args = $request->getArgs();
@@ -287,23 +286,7 @@ EOF;
 				serveFile('data/images/' . $args[0], 'data/images');
 				exit;
 			case HyphaRequest::HYPHA_SYSTEM_PAGE_INDEX:
-				$hyphaHtml->writeToElement('langList', hypha_indexLanguages('', ''));
-				switch ($args[0]) {
-					case 'images':
-						$hyphaHtml->writeToElement('pagename', __('image-index'));
-						$hyphaHtml->writeToElement('main', hypha_indexImages());
-						break;
-					case 'files':
-						$hyphaHtml->writeToElement('pagename', __('file-index'));
-						$hyphaHtml->writeToElement('main', hypha_indexFiles());
-						break;
-					default:
-						$languageName = $isoLangList[$O_O->getContentLanguage()];
-						$languageName = substr($languageName, 0, strpos($languageName, ' ('));
-						$hyphaHtml->writeToElement('pagename', __('page-index').': '.$languageName);
-						$hyphaHtml->writeToElement('main', hypha_indexPages($O_O->getContentLanguage()));
-						break;
-				}
+				$hyphaPage = new indexpage($O_O);
 				break;
 			case HyphaRequest::HYPHA_SYSTEM_PAGE_TAG_INDEX:
 				$hyphaPage = new tagindexpage($O_O);

--- a/system/datatypes/index.php
+++ b/system/datatypes/index.php
@@ -34,6 +34,8 @@
 			if ($language === null)
 				$language = $this->O_O->getContentLanguage();
 			$isoLangList = Language::getIsoList();
+			if (!array_key_exists($language, $isoLangList))
+				return '404';
 			$languageName = $isoLangList[$language];
 			$languageName = substr($languageName, 0, strpos($languageName, ' ('));
 

--- a/system/datatypes/index.php
+++ b/system/datatypes/index.php
@@ -30,7 +30,9 @@
 		}
 
 		public function pageIndexView(HyphaRequest $request) {
-			$language = $this->O_O->getContentLanguage();
+			$language = $request->getArg(0);
+			if ($language === null)
+				$language = $this->O_O->getContentLanguage();
 			$isoLangList = Language::getIsoList();
 			$languageName = $isoLangList[$language];
 			$languageName = substr($languageName, 0, strpos($languageName, ' ('));

--- a/system/datatypes/index.php
+++ b/system/datatypes/index.php
@@ -1,0 +1,74 @@
+<?php
+/*
+	Class: indexpage
+	Shows index page for various types of data.
+*/
+	class indexpage extends HyphaSystemPage {
+		const PATH_IMAGES = 'images';
+		const PATH_FILES = 'files';
+
+		function __construct(RequestContext $O_O) {
+			parent::__construct($O_O);
+		}
+
+		public function process(HyphaRequest $request) {
+			$this->html->writeToElement('langList', hypha_indexLanguages('', ''));
+			switch ([$request->getView(), $request->getCommand()]) {
+				case [self::PATH_IMAGES,        null]:   return $this->imageIndexView($request);
+				case [self::PATH_FILES,         null]:   return $this->fileIndexView($request);
+				default:                                 return $this->pageIndexView($request);
+			};
+		}
+		public function imageIndexView(HyphaRequest $request) {
+			$this->html->writeToElement('pagename', __('image-index'));
+			$this->html->writeToElement('main', 'image index is not yet implemented');
+		}
+
+		public function fileIndexView(HyphaRequest $request) {
+			$this->html->writeToElement('pagename', __('file-index'));
+			$this->html->writeToElement('main', 'file index is not yet implemented');
+		}
+
+		public function pageIndexView(HyphaRequest $request) {
+			$language = $this->O_O->getContentLanguage();
+			$isoLangList = Language::getIsoList();
+			$languageName = $isoLangList[$language];
+			$languageName = substr($languageName, 0, strpos($languageName, ' ('));
+
+			// get list of available pages and sort alphabetically
+			foreach(hypha_getPageList() as $page) {
+				$lang = hypha_pageGetLanguage($page, $language);
+				if ($lang) if ($this->O_O->isUser() || ($page->getAttribute('private')!='on')) {
+					$pageList[] = $lang->getAttribute('name').($page->getAttribute('private')=='on' ? '&#;' : '');
+					$pageListDatatype[$lang->getAttribute('name')] = $page->getAttribute('type');
+				}
+			}
+			if ($pageList) array_multisort(array_map('strtolower', $pageList), $pageList);
+
+			// add capitals
+			$capital = 'A';
+			$first = true;
+			if ($pageList) foreach($pageList as $pagename) {
+				while($capital < strtoupper($pagename[0])) $capital++;
+				if (strtoupper($pagename[0]) == $capital) {
+					if (!$first) {
+						$htmlList[] = '</div>';
+					}
+					$htmlList[] = '<div class="letter-wrapper">';
+					$htmlList[] = '<div class="letter">'.$capital.'</div>';
+					$capital++;
+					$first = false;
+				}
+				$privatePos = strpos($pagename, '&#;');
+				if ($privatePos) $pagename = substr($pagename, 0, $privatePos);
+				$htmlList[] = '<div class="index-item type_'.$pageListDatatype[$pagename].' '.($privatePos ? 'is-private' : 'is-public').'"><a href="'.$language.'/'.$pagename.'">'.showPagename($pagename).'</a></div>';
+			}
+
+			$html = '<div class="index">';
+			foreach($htmlList as $htmlLine) $html.= $htmlLine;
+			$html.= '</div>';
+
+			$this->html->writeToElement('pagename', __('page-index').': '.$languageName);
+			$this->html->writeToElement('main', $html);
+	}
+}

--- a/system/datatypes/settings.php
+++ b/system/datatypes/settings.php
@@ -32,10 +32,6 @@
 		}
 
 		function process(HyphaRequest $request) {
-//			global $isoLangList, $html;
-//			if ($view=='register') $html->pagename =  'registration';
-//			elseif ($this->hypha->login) $html->pagename = 'settings';
-//			else return notify('error', __('login-to-view'));
 			switch ($this->getArg(0)) {
 				case 'user': $this->editAccount($this->getArg(1)); break;
 				case 'invite': $this->editInvitation(); break;

--- a/system/datatypes/settings.php
+++ b/system/datatypes/settings.php
@@ -32,6 +32,9 @@
 		}
 
 		function process(HyphaRequest $request) {
+			if (!isUser() && $this->getArg(0) != 'register')
+				return ['redirect', $request->getRootUrl()];
+
 			switch ($this->getArg(0)) {
 				case 'user': $this->editAccount($this->getArg(1)); break;
 				case 'invite': $this->editInvitation(); break;


### PR DESCRIPTION
This allows selecting the language in the index again, which is a part of #310.

This also has some refactoring to put the index generation code into its own datatype class (and some refactoring of the settings class, while I was there, even though not strictly related to this fix).