### PR TITLE
Backport php-dom-wrapper changes for 7.4 compatibility

### DIFF
--- a/system/php-dom-wrapper/Traits/TraversalTrait.php
+++ b/system/php-dom-wrapper/Traits/TraversalTrait.php
@@ -14,18 +14,6 @@ use Symfony\Component\CssSelector\CssSelector;
  */
 trait TraversalTrait
 {
-    /** @see CommonTrait::collection() */
-    abstract public function collection();
-
-    /** @see CommonTrait::document() */
-    abstract public function document();
-
-    /** @see CommonTrait::result() */
-    abstract public function result($nodeList);
-
-    /** @see ManipulationTrait::inputAsNodeList() */
-    abstract public function inputAsNodeList($input);
-
     /**
      * @param Traversable|array $nodes
      *


### PR DESCRIPTION
This removes some abstract method definitions, which were defined public
here, but protected elsewhere. On PHP7.4, this produces:

    PHP Fatal error:  Access level to DOMWrap\\Traits\\ManipulationTrait::inputAsNodeList() must be public (as in class DOMWrap\\Traits\\TraversalTrait)

Since these abstract definitions are apparently not needed, just remove
them. This change is backported from upstream commit:

    https://github.com/scotteh/php-dom-wrapper/commit/8d332bf

Fixes: #312