### PR TITLE
peer_reviewed_article: Pass single HyphaDomElement to addDiscussion

### DIFF
--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -593,7 +593,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		$this->xml->lockAndReload();
 
 		// store discussion and comment
-		$discussionContainer = $this->xml->find($type);
+		$discussionContainer = $this->xml->find($type)->first();
 		$discussion = $this->addDiscussion($discussionContainer, $form, $dataFieldSuffix);
 		$comment = $this->addDiscussionComment($discussion, $form, $dataFieldSuffix);
 		$this->xml->saveAndUnlock();
@@ -899,7 +899,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param string dataFieldSuffix
 	 * @return HyphaDomElement
 	 */
-	private function addDiscussion(NodeList $discussionContainer, WymHTMLForm $form, $dataFieldSuffix) {
+	private function addDiscussion(HyphaDomElement $discussionContainer, WymHTMLForm $form, $dataFieldSuffix) {
 		$this->xml->requireLock();
 
 		/** @var HyphaDomElement $discussion */


### PR DESCRIPTION
Previously, this would pass a NodeList containing (normally) just a
single element. However, a NodeList does not seem to have a `nodeName`
property, which `addDiscussion` used to differentiate between review and
public comments.

This caused `addDiscussion` treat review discussions as public
discussions, leaving out the `user` attribute. This in turn prevented
users from resolving their own blocking comments, since there was no
longer a record of the initiator of a discussion (#318).

Passing a single HyphaDomElement rather than a NodeList to
`addDiscussion()` makes the latter work as expected again.

This fixes #318.