### PR TITLE
Improve dump function for NodeList and DomNode

### DIFF
--- a/system/core/events.php
+++ b/system/core/events.php
@@ -549,11 +549,9 @@
 		}
 		session_write_close();
 
-		if (count($hyphaDumpList)) {
-			foreach ($hyphaDumpList as $vars) {
-				foreach ($vars as &$value) $value = json_encode($value);
-				call_user_func_array([$html, 'writeScript'], ['console.log(' . implode(', ', $vars) . ');']);
-			}
+		foreach ($hyphaDumpList as $vars) {
+			$vars = array_map('json_encode', $vars);
+			$html->writeScript('console.log(' . implode(', ', $vars) . ');');
 		}
 	}
 

--- a/system/core/events.php
+++ b/system/core/events.php
@@ -550,7 +550,6 @@
 		session_write_close();
 
 		foreach ($hyphaDumpList as $vars) {
-			$vars = array_map('json_encode', $vars);
 			$html->writeScript('console.log(' . implode(', ', $vars) . ');');
 		}
 	}
@@ -575,6 +574,8 @@
 		$line = $caller['line'];
 		array_unshift($vars, $file . ':' . $line);
 
-		// adds the variables to the $hyphaDumpList for later processing
-		$hyphaDumpList[] = $vars;
+		// serialize now, rather than in addDumps, to capture
+		// the current state of objects (rather than the state
+		// at the end of the request).
+		$hyphaDumpList[] = array_map('json_encode', $vars);
 	}

--- a/system/core/events.php
+++ b/system/core/events.php
@@ -550,7 +550,7 @@
 		session_write_close();
 
 		foreach ($hyphaDumpList as $vars) {
-			$html->writeScript('console.log(' . implode(', ', $vars) . ');');
+			$html->writeScript('console.log(' . implode(', ', $vars) . ");\n");
 		}
 	}
 

--- a/system/core/various.php
+++ b/system/core/various.php
@@ -147,3 +147,15 @@
 		// Let the CssSelector library (within php-dom-wrapper) do the hard work
 		return Symfony\Component\CssSelector\XPath\Translator::getXpathLiteral($value);
 	}
+
+	/*
+		Function: is_iterable
+
+		Implementation of PHP's builtin is_iterable for PHP < 7.1.
+		Taken from https://www.php.net/manual/en/function.is-iterable.php#122574
+	*/
+	if (!function_exists('is_iterable')) {
+	    function is_iterable($obj) {
+		return is_array($obj) || (is_object($obj) && ($obj instanceof \Traversable));
+	    }
+	}


### PR DESCRIPTION
This makes some improvements to the `dump()` function that logs values to the javascript console from PHP.

In particular this improves the way that a `NodeList` and `DomNode` are dumped. For example, `dump($hyphaXml->find('user'));` would result in:

![image](https://user-images.githubusercontent.com/194491/82305153-91128480-99bd-11ea-9d82-5d63637ffeba.png)

This shows the nodeList with an expandable elements list, and each DomNode in the list is shown as a native Javascript DomNode, which can be traversed interactively.

Without this PR, dumping a `NodeList` or `DomNode` would just show `Object { }` in the console.