### PR TITLE
Multiple hypha commands

### DIFF
--- a/data/themes/default/hypha.css
+++ b/data/themes/default/hypha.css
@@ -171,24 +171,24 @@ a.nopagelink {
  padding: 10px;
 }
 
-#hyphaCommands {
+.hyphaCommands {
  text-align: right;
  width: 100%;
 }
 
-#hyphaCommands a {
+.hyphaCommands a {
  background:#ddd;
  padding: 5px 10px;
  display: inline-block;
  text-decoration: none;
 }
 
-#hyphaCommands a:hover {
+.hyphaCommands a:hover {
  background: #aaa;
  color: #fff;
 }
 
-#hyphaCommands .menu-item {
+.hyphaCommands .menu-item {
  padding-right: 10px;
 }
 

--- a/data/themes/default/hypha.html
+++ b/data/themes/default/hypha.html
@@ -9,7 +9,7 @@
         <div id="menu" class="nav-left"/>
       </nav>
       <nav class="tabs user">
-        <div id="hyphaCommands" class="nav-right" />
+        <div class="hyphaCommands nav-right" />
       </nav>
       <div id="login" />
       <div id="trail" />

--- a/index.php
+++ b/index.php
@@ -136,16 +136,16 @@
 	registerPostProcessingFunction('dewikify');
 
 	// add hypha commands and navigation
-	$_cmds[] = '<a href="index/'.$hyphaLanguage.'">'.__('index').'</a>';
+	$_cmds[] = '<a class="index" href="index/'.$hyphaLanguage.'">'.__('index').'</a>';
 	if (!$O_O->isUser()) {
 		addLoginRoutine($hyphaHtml);
-		$_cmds[] = '<a href="javascript:login();">'.__('login').'</a>';
+		$_cmds[] = '<a class="login" href="javascript:login();">'.__('login').'</a>';
 	}
 	else {
 		addNewPageRoutine($hyphaHtml, $hyphaRequest->getRelativeUrlPathParts(false), hypha_getDataTypes());
-		$_cmds[] = makeLink(__('new-page'), 'newPage();');
-		$_cmds[] = makeLink(__('settings'), makeAction('settings', '', ''));
-		$_cmds[] = makeLink(__('logout'), makeAction($hyphaRequest->getRelativeUrlPath(false),'logout',''));
+		$_cmds[] = makeLink(__('new-page'), 'newPage();', 'newPage');
+		$_cmds[] = makeLink(__('settings'), makeAction('settings', '', ''), 'settings');
+		$_cmds[] = makeLink(__('logout'), makeAction($hyphaRequest->getRelativeUrlPath(false),'logout',''), 'logout');
 	}
 	$hyphaHtml->writeToElement('hyphaCommands', implode('', $_cmds));
 	if ($O_O->isUser()) $hyphaHtml->writeToElement('hyphaCommands', '<br/><div id="loggedIn">'.__('logged-in-as').' `'.$O_O->getUser()->getAttribute('username').'`'.asterisk(isAdmin()).'</div>');

--- a/index.php
+++ b/index.php
@@ -147,7 +147,9 @@
 		$_cmds[] = makeLink(__('settings'), makeAction('settings', '', ''), 'settings');
 		$_cmds[] = makeLink(__('logout'), makeAction($hyphaRequest->getRelativeUrlPath(false),'logout',''), 'logout');
 	}
-	$hyphaHtml->writeToElement('hyphaCommands', implode('', $_cmds));
+	// A class is used by default, but also look for the
+	// #hyphaCommands id which was used in earlier versions.
+	$hyphaHtml->find('.hyphaCommands, #hyphaCommands')->html(implode('', $_cmds));
 	if ($O_O->isUser()) $hyphaHtml->writeToElement('hyphaCommands', '<br/><div id="loggedIn">'.__('logged-in-as').' `'.$O_O->getUser()->getAttribute('username').'`'.asterisk(isAdmin()).'</div>');
 
 	// obfuscate email addresses to strangers. It's ok to send readable addresses to logged in members. This also prevents conflicts in the editor.

--- a/system/core/various.php
+++ b/system/core/various.php
@@ -107,9 +107,11 @@
 		Parameters:
 		$label - anchor text
 		$action - javascript action
+		$class - optional CSS class
 	*/
-	function makeLink($label, $action) {
-		return '<a href="javascript:'.$action.'">'.$label.'</a>';
+	function makeLink($label, $action, $class = null) {
+		$classattr = ($class ? " class=".$class : "");
+		return '<a'.$classattr.' href="javascript:'.$action.'">'.$label.'</a>';
 	}
 
 	/*


### PR DESCRIPTION
This is a fix for #323, to support adding `hyphaCommands` (login/logout/index/settings/new page) in multiple places on the page.