### PR TITLE
Fix wikifying of root-relative links

### DIFF
--- a/system/core/base.php
+++ b/system/core/base.php
@@ -704,10 +704,14 @@
 		make it a relative to $hyphaUrl.
 	*/
 	function hypha_make_relative($url) {
-		global $hyphaUrl;
-		$len = strlen($hyphaUrl);
-		if (substr($url, 0, $len) == $hyphaUrl)
-			$url = substr($url, $len);
+		global $O_O;
+
+		// Handle urls like https://mydomain.tld/path/en/pagename
+		$remove = $O_O->getRequest()->getRootUrl();
+		$len = strlen($remove);
+		if (substr($url, 0, $len) == $remove)
+			return substr($url, $len);
+
 		return $url;
 	}
 

--- a/system/core/base.php
+++ b/system/core/base.php
@@ -712,6 +712,12 @@
 		if (substr($url, 0, $len) == $remove)
 			return substr($url, $len);
 
+		// Handle urls like /path/en/pagename
+		$remove = $O_O->getRequest()->getRootUrlPath();
+		$len = strlen($remove);
+		if (substr($url, 0, $len) == $remove)
+			return substr($url, $len);
+
 		return $url;
 	}
 


### PR DESCRIPTION
This makes sure that a link like `/en/pagename` is properly wikified too, rather than just `en/pagename` or `https://domain.tld/en/pagename`.