### PR TITLE
Store CSRF token in a cookie

### DIFF
--- a/index.php
+++ b/index.php
@@ -121,9 +121,9 @@
 	// Load page and execute the posted command. This
 	// is tried twice, since some commands need to run before
 	// loading the page, and some commands need to run after.
-	executePostedCommand(); // Might redirect and exit
+	executePostedCommand($O_O); // Might redirect and exit
 	loadPage($O_O);
-	executePostedCommand(); // Might redirect and exit
+	executePostedCommand($O_O); // Might redirect and exit
 
 	/*
 		Group: Stage 6 - Load page and process query

--- a/system/core/HyphaRequest.php
+++ b/system/core/HyphaRequest.php
@@ -134,6 +134,16 @@
 			return sprintf('%s://%s%s', $scheme, $host, $this->rootUrlPath);
 		}
 
+		/**
+		 * Returns the path component of the root url, i.e. the
+		 * part after the hostname. This always starts and ends
+		 * with a slash (which might be the same when running
+		 * in the root of the domain).
+		 */
+		public function getRootUrlPath() {
+			return $this->rootUrlPath;
+		}
+
 		public function getScheme() {
 			// Apache 2.4+ has REQUEST_SCHEME
 			if (array_key_exists('REQUEST_SCHEME', $_SERVER))

--- a/system/core/HyphaRequest.php
+++ b/system/core/HyphaRequest.php
@@ -148,7 +148,7 @@
 			// Apache 2.4+ has REQUEST_SCHEME
 			if (array_key_exists('REQUEST_SCHEME', $_SERVER))
 				return $_SERVER['REQUEST_SCHEME'];
-			if (array_key_exists('HTTPS', $_SERVER) && $_SERVER['HTTPS'] == 'on')
+			if ($this->isSecure())
 				return 'https';
 			return 'http';
 		}
@@ -159,6 +159,10 @@
 
 		public function getPort() {
 			return $_SERVER['SERVER_PORT'];
+		}
+
+		public function isSecure() {
+			return array_key_exists('HTTPS', $_SERVER) && $_SERVER['HTTPS'] === 'on';
 		}
 
 		/**

--- a/system/core/RequestContext.php
+++ b/system/core/RequestContext.php
@@ -120,6 +120,49 @@
 			return $this->dictionary;
 		}
 
+		/*
+			Function: getOrGenerateCsrfToken
+
+			Returns the CsrfToken to be used for all
+			subsequent POST requests. If there is no token
+			yet, it will be generated automatically.
+		*/
+		public function getOrGenerateCsrfToken() {
+			if (!isset($_SESSION['hyphaCsrfToken'])) {
+				session_start();
+				$this->regenerateCsrfToken();
+				session_write_close();
+			}
+
+			return $_SESSION['hyphaCsrfToken'];
+		}
+
+		/*
+			Function: regenerateCsrfToken
+
+			Regenerate the CSRF token. Should be called when a new
+			session starts, such as during login. Should be called
+			while the session is already open (e.g. between
+			session_start() and session_write_close()).
+		*/
+		public function regenerateCsrfToken() {
+			$_SESSION['hyphaCsrfToken'] = bin2hex(openssl_random_pseudo_bytes(8));
+		}
+
+		/*
+			Function: csrfValid
+
+			Returns whether the request is a POST request
+			that contains a valid CSRF token in the request
+			parameters. When this returns false, a POST
+			request should not be processed.
+		*/
+		public function validCsrfToken() {
+			$received = $this->getRequest()->getPostValue('csrfToken');
+			$expected = $this->getOrGenerateCsrfToken();
+			return $received === $expected;
+		}
+
 		/**
 		 * @return HyphaRequest
 		 */

--- a/system/core/events.php
+++ b/system/core/events.php
@@ -293,17 +293,19 @@
 	}
 
 	// execute posted commands
-	function executePostedCommand() {
+	function executePostedCommand($O_O) {
 		static $processed = false;
+		$request = $O_O->getRequest();
 
-		if(!$processed && isset($_POST['command'])) {
-			if (!isset($_POST['csrfToken']) || $_POST['csrfToken'] != getCsrfToken()) {
+		$command = $request->getPostValue('command');
+		if (!$processed && $command) {
+			if ($request->getPostValue('csrfToken') != getCsrfToken()) {
 				notify('error', __('csrf-error'));
 				$processed = true;
 				return;
 			}
 
-			$result = processCommand($_POST['command'], isset($_POST['argument']) ? $_POST['argument'] : null);
+			$result = processCommand($command, $request->getPostValue('argument', null));
 			if ($result !== false) {
 				// Command was handled
 				$processed = true;

--- a/system/core/events.php
+++ b/system/core/events.php
@@ -294,17 +294,19 @@
 
 	// execute posted commands
 	function executePostedCommand() {
-		if(isset($_POST['command'])) {
+		static $processed = false;
+
+		if(!$processed && isset($_POST['command'])) {
 			if (!isset($_POST['csrfToken']) || $_POST['csrfToken'] != getCsrfToken()) {
 				notify('error', __('csrf-error'));
-				unset($_POST['command']);
+				$processed = true;
 				return;
 			}
 
 			$result = processCommand($_POST['command'], isset($_POST['argument']) ? $_POST['argument'] : null);
 			if ($result !== false) {
 				// Command was handled
-				unset($_POST['command']);
+				$processed = true;
 				processCommandResult($result);
 			}
 		}

--- a/system/core/users.php
+++ b/system/core/users.php
@@ -16,13 +16,14 @@
 	*/
 	registerCommandCallback('login', 'login');
 	function login() {
+		global $O_O;
 		$user = hypha_getUserByName($_POST['loginUsername']);
 		if ($user && $user->getAttribute('rights') != 'exmember' && verifyPassword($_POST['loginPassword'], $user->getAttribute('password'))) {
 			session_start();
 			// Use a brand new session id for extra security
 			session_regenerate_id();
 			$_SESSION['hyphaLogin'] = $user->getAttribute('id');
-			regenerateCsrfToken();
+			$O_O->regenerateCsrfToken();
 			session_write_close();
 		}
 		else {


### PR DESCRIPTION
This is a subset of PR #316, with just the commits needed to move the CSRF token into a cookie. This was originally just a cleanup, but it has since been shown that having the CSRF token in the session can cause dataloss when visitors submit a (lengthy) comment and the session has expired since they first loaded the article page. In that case, the CSRF token will be invalid and the request rejected rather forcefully, losing the submitted comment.

Moving the CSRF token to a cookie ensures that the token survives until the browser closes, which should prevent this dataloss.