### PR TITLE
Convert festival to new datatype style

### DIFF
--- a/data/themes/default/hypha.css
+++ b/data/themes/default/hypha.css
@@ -862,6 +862,57 @@ textarea{
 .festivalTimetable .tableRowHeadingEven {
 	background-color:#bbb;
 }
+
+.festivalForm th {
+	text-align: right;
+}
+
+.festivalForm input, .festivalForm select, .festivalForm textarea {
+	width: 400px;
+}
+
+.festivalForm textarea {
+	height: 100px;
+}
+
+.contribution h2 {
+	clear: left;
+}
+
+/* Include #main to override #main img */
+#main .contribution img {
+	float: left;
+	border: 0px;
+	margin-right: 10px;
+}
+
+.contribution .event {
+	clear: left;
+}
+
+.contribution .date {
+	font-weight: bold;
+}
+
+.contribution .time-and-place {
+	margin-left: 1em;
+}
+
+.contribution .website {
+	clear: left;
+}
+
+table.contributions .description,
+table.contributions .notes {
+    padding-left: 50px;
+}
+
+/* Include #main to override #main img */
+#main table.contributions .description img {
+    float: left;
+    margin: 5px 10px 0 0;
+}
+
 body.type_peer_reviewed_article .input-wrapper.field_type_editor:not(.field_name_text) .wym_iframe iframe {
 	height: 150px;
 }

--- a/system/core/communication.php
+++ b/system/core/communication.php
@@ -91,9 +91,7 @@
 		setInnerHtml($body, preg_replace('/\b([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4})\b/ie', "'<span class=\"obfuscate\">'.strrev('$1').'</span>'", getInnerHtml($body)));
 
 		// add a javascript function to undo these operations on the client side
-		ob_start();
-?>
-	<script>
+		$js = <<<'EOD'
 	function unobfuscateEmail(elem) {
 		// reverse visible name
 		elem.innerHTML = elem.innerHTML.replace(/(<span class="obfuscate">(.*?)<\/span>)/g, function(str, span, email) {return email.split('').reverse().join('')});
@@ -102,9 +100,8 @@
 		// reverse the href mailto attribute
 		elem.innerHTML = elem.innerHTML.replace(/([\'|\"]mailto:([A-Za-z0-9\._%\+-@]+?)[\'|\"])/g, function(str, href, email) {return 'mailto:'+email.split('').reverse().join('')});
 	}
-	</script>
-<?php
-		$html->writeScript(ob_get_clean());
+EOD;
+		$html->writeScript($js);
 
 		// invoke the unobfuscateEmail routine only after the document is fully loaded. To avoid jQuery onload when it's not strictly needed we deploy a <script> element at the end of the HTML document
 		$html->writeToElement('main', '<script>unobfuscateEmail(document.body);</script>');

--- a/system/datatypes/festival.php
+++ b/system/datatypes/festival.php
@@ -10,7 +10,7 @@
 	Class: festivalpage
  */
 	class festivalpage extends HyphaDatatypePage {
-		public $xml;
+		protected $xml;
 
 		const FIELD_NAME_AMOUNT = 'amount';
 		const FIELD_NAME_CATEGORY = 'category';
@@ -102,7 +102,7 @@
 			return __('datatype.name.festivalpage');
 		}
 
-		function process(HyphaRequest $request) {
+		public function process(HyphaRequest $request) {
 			$this->html->writeToElement('pagename', showPagename($this->pagename) . ' ' . asterisk($this->privateFlag));
 
 			if (isUser() && !in_array($request->getView(), [self::PATH_SETTINGS])) {
@@ -155,7 +155,7 @@
 		 * attribute from it. If no attribute is given, the
 		 * "value" attribute is returned.
 		 */
-		function getConfig($id, $attribute = self::CONFIG_ATTR_VALUE) {
+		protected function getConfig($id, $attribute = self::CONFIG_ATTR_VALUE) {
 			$config = $this->getConfigElement($id);
 			if (!$config)
 				return '';
@@ -170,7 +170,7 @@
 		 * it is created using the given tagname. Otherwise,
 		 * null is returned.
 		 */
-		function getConfigElement($id, $tagname = null) {
+		protected function getConfigElement($id, $tagname = null) {
 			$elem = $this->xml->getElementById($id);
 			if (!$elem && $tagname) {
 				$elem = $this->xml->createElement($tagname);
@@ -187,7 +187,7 @@
 		 * is set. If the tag does not exist, it is created,
 		 * using the given tagname.
 		 */
-		function setConfig($id, $value, $tagname = self::CONFIG_TAG, $attribute = self::CONFIG_ATTR_VALUE) {
+		protected function setConfig($id, $value, $tagname = self::CONFIG_TAG, $attribute = self::CONFIG_ATTR_VALUE) {
 			$config = $this->getConfigElement($id, $tagname);
 			return $config->setAttribute($attribute, $value);
 		}
@@ -195,7 +195,7 @@
 		/**
 		 * Show the admin display with registrations.
 		 */
-		function participantsView(HyphaRequest $request) {
+		protected function participantsView(HyphaRequest $request) {
 			if (!isUser()) return notify('error', __('login-to-edit'));
 
 			$stats = [];
@@ -246,7 +246,7 @@
 		/**
 		 * Show the admin display with contributions.
 		 */
-		function contributionsView(HyphaRequest $request) {
+		protected function contributionsView(HyphaRequest $request) {
 			// TODO: Styling
 			if (!isUser()) return notify('error', __('login-to-edit'));
 			$table = new HTMLTable();
@@ -289,7 +289,7 @@
 		/**
 		 * @return HTMLForm
 		 */
-		function createSettingsForm(array $values=[]) {
+		protected function createSettingsForm(array $values=[]) {
 			$html = <<<EOF
 				<table>
 					<tr>
@@ -308,7 +308,7 @@ EOF;
 			return new HTMLForm($html, $values);
 		}
 
-		function settingsView(HyphaRequest $request) {
+		protected function settingsView(HyphaRequest $request) {
 			if (!isUser()) return notify('error', __('login-to-edit'));
 
 			// create form
@@ -332,7 +332,7 @@ EOF;
 			return null;
 		}
 
-		function settingsSaveAction(HyphaRequest $request) {
+		protected function settingsSaveAction(HyphaRequest $request) {
 			if (!isUser()) return notify('error', __('login-to-edit'));
 
 			// create form
@@ -352,7 +352,7 @@ EOF;
 			return ['redirect', $this->constructFullPath($this->pagename)];
 		}
 
-		function deleteAction(HyphaRequest $request) {
+		protected function deleteAction(HyphaRequest $request) {
 			if (!isAdmin()) return notify('error', __('login-as-admin-to-delete'));
 
 			$this->deletePage();
@@ -412,12 +412,12 @@ EOF;
 		/**
 		 * The signup form. Here's where the fun starts.
 		 */
-		function signupView(HyphaRequest $request) {
+		protected function signupView(HyphaRequest $request) {
 			$form = $this->createSignupForm();
 			return $this->signupViewRender($request, $form);
 		}
 
-		function signupViewRender(HyphaRequest $request, HTMLForm $form) {
+		protected function signupViewRender(HyphaRequest $request, HTMLForm $form) {
 			$form->updateDom();
 
 			$this->html->find('#main')->append($form);
@@ -434,7 +434,7 @@ EOF;
 		 * /contribute, depending on whether there is something to
 		 * pay.
 		 */
-		function signupAction(HyphaRequest $request) {
+		protected function signupAction(HyphaRequest $request) {
 			// create form
 			$form = $this->createSignupForm($request->getPostData());
 
@@ -486,7 +486,7 @@ EOF;
 		 * For unpaid registrations, show a message that
 		 * confirmation is needed.
 		 */
-		function confirmationNeededView(HyphaRequest $request) {
+		protected function confirmationNeededView(HyphaRequest $request) {
 			$this->html->find('#pagename')->text(__('festival-confirmation-needed'));
 			$main = $this->html->find('#main');
 			$message = __('festival-complete-by-confirming');
@@ -498,7 +498,7 @@ EOF;
 		 * For unpaid registrations, this link needs to be
 		 * clicked to confirm the registration.
 		 */
-		function confirmView(HyphaRequest $request) {
+		protected function confirmView(HyphaRequest $request) {
 			$this->xml->lockAndReload();
 			$participant = $this->checkKeyArguments($request, [self::TAG_PARTICIPANT]);
 			if (!$participant) {
@@ -541,7 +541,7 @@ EOF;
 		 * is already complete, this redirects to the
 		 * /contribute page.
 		 */
-		function payView(HyphaRequest $request) {
+		protected function payView(HyphaRequest $request) {
 			$this->xml->lockAndReload();
 			$participant = $this->checkKeyArguments($request, [self::TAG_PARTICIPANT]);
 			if (!$participant) {
@@ -574,7 +574,7 @@ EOF;
 		 * the payment was already completed, then it redirects
 		 * to the /contribute page.
 		 */
-		function payAction(HyphaRequest $request) {
+		protected function payAction(HyphaRequest $request) {
 			$this->xml->lockAndReload();
 			$participant = $this->checkKeyArguments($request, [self::TAG_PARTICIPANT]);
 			if(!$participant) {
@@ -596,7 +596,7 @@ EOF;
 			return ['redirect', $url];
 		}
 
-		function paymenthookView(HyphaRequest $request) {
+		protected function paymenthookView(HyphaRequest $request) {
 			$this->xml->lockAndReload();
 			$participant = $this->checkKeyArguments($request, [self::TAG_PARTICIPANT]);
 			if(!$participant) {
@@ -707,7 +707,7 @@ EOF;
 		/**
 		 * Show the contribution form.
 		 */
-		function contributeView(HyphaRequest $request) {
+		protected function contributeView(HyphaRequest $request) {
 			$obj = $this->checkKeyArguments($request, [self::TAG_CONTRIBUTION, self::TAG_PARTICIPANT], true);
 			if (!$obj)
 				return '404';
@@ -737,7 +737,7 @@ EOF;
 			return $this->contributeViewRender($request, $form, $editing);
 		}
 
-		function contributeViewrender(HyphaRequest $request, HTMLForm $form, $editing) {
+		protected function contributeViewrender(HyphaRequest $request, HTMLForm $form, $editing) {
 			// Update the form to include any data
 			$form->updateDom();
 
@@ -753,7 +753,7 @@ EOF;
 		/**
 		 * Handle the contribution form.
 		 */
-		function contributionSaveAction(HyphaRequest $request) {
+		protected function contributionSaveAction(HyphaRequest $request) {
 			$this->xml->lockAndReload();
 
 			$obj = $this->checkKeyArguments($request, [self::TAG_CONTRIBUTION, self::TAG_PARTICIPANT], true);
@@ -853,7 +853,7 @@ EOF;
 		}
 
 
-		function lineupView(HyphaRequest $request) {
+		protected function lineupView(HyphaRequest $request) {
 			$html = '';
 			$contributions = $this->xml->documentElement->getOrCreate(self::TAG_CONTRIBUTION_CONTAINER)->children();
 			foreach($contributions as $contribution) {
@@ -868,7 +868,7 @@ EOF;
 		 * Build the HTML for a single contribution in the
 		 * lineup.
 		 */
-		function buildContribution($contribution) {
+		protected function buildContribution($contribution) {
 			$html = '<div class="contribution">';
 			// artist and title
 			$id = $contribution->getId();
@@ -926,7 +926,7 @@ EOF;
 			return $html;
 		}
 
-		function timetableView(HyphaRequest $request) {
+		protected function timetableView(HyphaRequest $request) {
 			// Make a list of all days, and per day all
 			// locations and the begin and end time.
 			$contributions = $this->xml->documentElement->getOrCreate(self::TAG_CONTRIBUTION_CONTAINER)->children();
@@ -1038,7 +1038,7 @@ EOF;
 			$this->html->find('#main')->html($html);
 		}
 
-		function timetocols($t1, $t2) {
+		protected function timetocols($t1, $t2) {
 			$c1=12*intval(substr($t1,0,2)) + intval(substr($t1,3,2))/5;
 			$c2=12*intval(substr($t2,0,2)) + intval(substr($t2,3,2))/5;
 			return $c2 - $c1;
@@ -1049,7 +1049,7 @@ EOF;
 		 * participant and create an initial payment.
 		 * Should be called with the XML lock held.
 		 */
-		function setupPayment($participant, $amount) {
+		protected function setupPayment($participant, $amount) {
 			$participant->ownerDocument->requireLock();
 			$participant->setAttribute(self::ATTR_PARTICIPANT_PAYMENT_DESCRIPTION, $this->getConfig(self::CONFIG_ID_TITLE) . ' - ' . $participant->getAttribute(self::ATTR_PARTICIPANT_NAME));
 			$participant->setAttribute(self::ATTR_PARTICIPANT_PAYMENT_AMOUNT, $amount);
@@ -1067,7 +1067,7 @@ EOF;
 		 * its status.
 		 * Should be called with the XML lock held.
 		 */
-		function createPayment($participant) {
+		protected function createPayment($participant) {
 			$participant->ownerDocument->requireLock();
 			$complete_url = $this->constructFullPath($this->pagename . '/' . self::PATH_PAY . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
 			$hook_url = $this->constructFullPath($this->pagename . '/' . self::PATH_PAYMENTHOOK . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
@@ -1106,7 +1106,7 @@ EOF;
 		 *
 		 * Should be called with the XML lock held.
 		 */
-		function checkPayment($participant, $create_new = false) {
+		protected function checkPayment($participant, $create_new = false) {
 			// load Mollie script
 			require_once('system/Mollie/API/Autoloader.php');
 			$mollie = new Mollie_API_Client;
@@ -1143,7 +1143,7 @@ EOF;
 		 * failed payment, but a note is still added to the
 		 * digest.
 		 */
-		function processPaymentChange($participant, $payment, $mail_failed) {
+		protected function processPaymentChange($participant, $payment, $mail_failed) {
 			$participant->setAttribute(self::ATTR_PARTICIPANT_PAYMENT_STATUS, $payment->status);
 			if ($payment->isPaid()) {
 				if (!$participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_TIMESTAMP)) {
@@ -1194,7 +1194,7 @@ EOF;
 		 * Retrieve the given mail from the translations and send it,
 		 * interpolating the given variables.
 		 */
-		function sendMail($to, $id, $vars) {
+		protected function sendMail($to, $id, $vars) {
 			$subject = __($id . '-subject', $vars);
 			$body = __($id . '-body', $vars);
 
@@ -1215,7 +1215,7 @@ EOF;
 		 * even if the key is not present. If no id is present
 		 * either, the user object itself will be returned.
 		 */
-		function checkKeyArguments(HyphaRequest $request, array $tags, $allow_user = false) {
+		protected function checkKeyArguments(HyphaRequest $request, array $tags, $allow_user = false) {
 			$id = $request->getArg(1);
 			if ($id) {
 				$obj = $this->xml->getElementById($id);

--- a/system/datatypes/festival.php
+++ b/system/datatypes/festival.php
@@ -629,14 +629,16 @@ EOF;
 				$email = false;
 			}
 
-			$digest = $name;
+			$vars = [
+				'name' => $name,
+				'contribution'=> $contribution->getAttribute('title') . ' - ' . $contribution->getAttribute('name'),
+			];
 			if ($editing)
-				$digest .= __('festival-edited-contribution');
+				$digest = __('festival-edited-contribution', $vars);
 			else
-				$digest .= __('festival-added-contribution');
+				$digest = __('festival-added-contribution', $vars);
 
-			$digest .= $contribution->getAttribute('title') . ' - ' . $contribution->getAttribute('name');
-			$digest .= ' (<a href="' . $edit_url . '">Edit contribution</a>)';
+			$digest .= ' (<a href="' . $edit_url . '">' . __('festival-digest-edit-contribution') . '</a>)';
 			writeToDigest($digest, 'festival-contribution');
 
 			if (!$editing && $email) {

--- a/system/datatypes/festival.php
+++ b/system/datatypes/festival.php
@@ -786,8 +786,11 @@ EOF;
 				$html.= "<table class=\"festivalTimetable\">";
 
 				// output row of invisible images to force a more or less regular time grid
+				// of 5 minute intervals (12 per hour)
 				$html.= "<tr><td></td>";
-				for ($c = 12*substr($daybegin,0,2); $c < 12*substr($dayend,0,2); $c++) $html.= '<td style="min-width: 10px;"></td>';
+				$hourstart = intval(substr($daybegin,0,2));
+				$hourend = intval(substr($dayend,0,2));
+				for ($c = 12*$hourstart; $c < 12*$hourend; $c++) $html.= '<td style="min-width: 10px;"></td>';
 				$html.= '</tr>';
 
 				// iterate over all locations
@@ -821,7 +824,7 @@ EOF;
 						// every 6 rows output time grid
 						if ($line%6==0) {
 							$html.= '<tr><th><div style="text-align:right;">'.__('time').'</div><div style="text-align:left;">'.__('location').'</div></th>';
-							for ($c = substr($daybegin,0,2); $c < substr($dayend,0,2); $c++) {
+							for ($c = $hourstart; $c < $hourend; $c++) {
 								$html.= '<th class="timeGridOdd" colspan="6">'.$c.'</th>';
 								$html.= '<th class="timeGridEven" colspan="6"></th>';
 							}
@@ -859,8 +862,8 @@ EOF;
 		}
 
 		function timetocols($t1, $t2) {
-			$c1=12*substr($t1,0,2) + substr($t1,3,2)/5;
-			$c2=12*substr($t2,0,2) + substr($t2,3,2)/5;
+			$c1=12*intval(substr($t1,0,2)) + intval(substr($t1,3,2))/5;
+			$c2=12*intval(substr($t2,0,2)) + intval(substr($t2,3,2))/5;
 			$c = $c2 - $c1;
 			return str_repeat("0", 3-strlen($c)).$c;
 		}

--- a/system/datatypes/festival.php
+++ b/system/datatypes/festival.php
@@ -1,6 +1,6 @@
 <?php
 /*
-        Module: festival
+	Module: festival
 
 	Collects various festival-related features, like signup and
 	timetables.
@@ -8,18 +8,94 @@
 
 /*
 	Class: festivalpage
-*/
+ */
 	class festivalpage extends HyphaDatatypePage {
+		public $xml;
+
+		const FIELD_NAME_AMOUNT = 'amount';
+		const FIELD_NAME_CATEGORY = 'category';
+		const FIELD_NAME_DESCRIPTION = 'description';
+		const FIELD_NAME_EMAIL = 'email';
+		const FIELD_NAME_IMAGE = 'image';
+		const FIELD_NAME_IMAGE_UPLOAD = 'image_upload';
+		const FIELD_NAME_NAME = 'name';
+		const FIELD_NAME_NOTES = 'notes';
+		const FIELD_NAME_PHONE = 'phone';
+		const FIELD_NAME_TITLE = 'title';
+		const FIELD_NAME_WEBSITE = 'website';
+
+		const PATH_CONFIRMATION_NEEDED = 'confirmation-needed';
+		const PATH_CONFIRM = 'confirm';
+		const PATH_CONTRIBUTE = 'contribute';
+		const PATH_CONTRIBUTIONS = 'contributions';
+		const PATH_LINEUP = 'lineup';
+		const PATH_PARTICIPANTS = 'participants';
+		const PATH_PAYMENTHOOK = 'paymenthook';
+		const PATH_PAY = 'pay';
+		const PATH_SETTINGS = 'settings';
+		const PATH_SIGNUP = 'signup';
+		const PATH_TIMETABLE = 'timetable';
+
+		const CMD_DELETE = 'delete';
+		const CMD_PAY = 'pay';
+		const CMD_SAVE = 'save';
+		const CMD_SIGNUP = 'signup';
+
+		const CONFIG_TAG = 'config';
+		const CONFIG_TAG_FORM = 'form';
+		const CONFIG_TAG_DAYS = 'config';
+		const CONFIG_TAG_LOCATIONS = 'config';
+		const CONFIG_ID_TITLE = 'festival-title';
+		const CONFIG_ID_SIGNUP_FORM = 'signup-form';
+		const CONFIG_ID_CONTRIBUTION_FORM = 'contribution-form';
+		const CONFIG_ID_DAYS = 'days';
+		const CONFIG_ID_LOCATIONS = 'locations';
+		const CONFIG_ATTR_VALUE = 'value';
+
+		const TAG_PARTICIPANTS_CONTAINER = 'participants';
+		const TAG_PARTICIPANT = 'participant';
+		const TAG_CONTRIBUTION_CONTAINER = 'contributions';
+		const TAG_CONTRIBUTION = 'contribution';
+
+		// Applies to both contribution and participant
+		const ATTR_KEY = 'key';
+
+		const ATTR_CONTRIBUTION_CATEGORY = 'category';
+		const ATTR_CONTRIBUTION_IMAGE = 'image';
+		const ATTR_CONTRIBUTION_KEY = self::ATTR_KEY;
+		const ATTR_CONTRIBUTION_NAME = 'name';
+		const ATTR_CONTRIBUTION_PARTICIPANT = 'participant';
+		const ATTR_CONTRIBUTION_TITLE = 'title';
+		const ATTR_CONTRIBUTION_WEBSITE = 'website';
+		const TAG_CONTRIBUTION_DESCRIPTION = 'description';
+		const TAG_CONTRIBUTION_NOTES = 'notes';
+		const TAG_CONTRIBUTION_EVENT = 'event';
+
+		const ATTR_PARTICIPANT_EMAIL_CONFIRMED = 'email-confirmed';
+		const ATTR_PARTICIPANT_EMAIL = 'email';
+		const ATTR_PARTICIPANT_KEY = self::ATTR_KEY;
+		const ATTR_PARTICIPANT_NAME = 'name';
+		const ATTR_PARTICIPANT_PAYMENT_AMOUNT = 'payment-amount';
+		const ATTR_PARTICIPANT_PAYMENT_DESCRIPTION = 'payment-description';
+		const ATTR_PARTICIPANT_PAYMENT_ID = 'payment-id';
+		const ATTR_PARTICIPANT_PAYMENT_STATUS = 'payment-status';
+		const ATTR_PARTICIPANT_PAYMENT_TIMESTAMP = 'payment-timestamp';
+		const ATTR_PARTICIPANT_PHONE = 'phone';
+
+		const ATTR_EVENT_DAY = 'day';
+		const ATTR_EVENT_LOCATION = 'location';
+		const ATTR_EVENT_BEGIN = 'begin';
+		const ATTR_EVENT_END = 'end';
+
+		const ATTR_DAY_DISPLAY = 'display';
+		const ATTR_DAY_BEGIN = 'begin';
+		const ATTR_DAY_END = 'end';
+		const ATTR_LOCATION_DISPLAY = 'display';
+
 		public function __construct($pageListNode, RequestContext $O_O) {
 			parent::__construct($pageListNode, $O_O);
 			$this->xml = new Xml('festival', Xml::multiLingualOn, Xml::versionsOff);
 			$this->xml->loadFromFile('data/pages/'.$pageListNode->getAttribute('id'));
-
-			registerCommandCallback('save', Array($this, 'handleSaveSettings'));
-			registerCommandCallback('signup', Array($this, 'handleSignup'));
-			registerCommandCallback('contribute', Array($this, 'handleContribute'));
-			registerCommandCallback('pay', Array($this, 'handlePay'));
-			registerCommandCallback('delete', Array($this, 'handleDelete'));
 		}
 
 		public static function getDatatypeName() {
@@ -27,76 +103,45 @@
 		}
 
 		function process(HyphaRequest $request) {
-			if (isUser() && !in_array($this->getArg(0), ['edit'])) {
+			$this->html->writeToElement('pagename', showPagename($this->pagename) . ' ' . asterisk($this->privateFlag));
+
+			if (isUser() && !in_array($request->getView(), [self::PATH_SETTINGS])) {
 				$commands = $this->html->find('#pageCommands');
-
-				$action = makeAction($this->language . '/' . $this->pagename . '/settings', '', '');
-				$button = makeButton(__('settings'), $action);
-				$commands->append($button);
-
-				$action = makeAction($this->language . '/' . $this->pagename . '/signup', '', '');
-				$button = makeButton(__('festival-signup'), $action);
-				$commands->append($button);
-
-				$action = makeAction($this->language . '/' . $this->pagename . '/contribute', '', '');
-				$button = makeButton(__('festival-contribute'), $action);
-				$commands->append($button);
-
-				$action = makeAction($this->language . '/' . $this->pagename . '/participants', '', '');
-				$button = makeButton(__('festival-participants'), $action);
-				$commands->append($button);
-
-				$action = makeAction($this->language . '/' . $this->pagename . '/contributions', '', '');
-				$button = makeButton(__('festival-contributions'), $action);
-				$commands->append($button);
-
-				$action = makeAction($this->language . '/' . $this->pagename . '/lineup', '', '');
-				$button = makeButton(__('festival-lineup'), $action);
-				$commands->append($button);
-
-				$action = makeAction($this->language . '/' . $this->pagename . '/timetable', '', '');
-				$button = makeButton(__('festival-timetable'), $action);
-				$commands->append($button);
+				$commands->append($this->makeActionButton(__('settings'), self::PATH_SETTINGS));
+				$commands->append($this->makeActionButton(__('festival-signup'), self::PATH_SIGNUP));
+				$commands->append($this->makeActionButton(__('festival-contribute'), self::PATH_CONTRIBUTE));
+				$commands->append($this->makeActionButton(__('festival-participants'), self::PATH_PARTICIPANTS));
+				$commands->append($this->makeActionButton(__('festival-contributions'), self::PATH_CONTRIBUTIONS));
+				$commands->append($this->makeActionButton(__('festival-lineup'), self::PATH_LINEUP));
+				$commands->append($this->makeActionButton(__('festival-timetable'), self::PATH_TIMETABLE));
 
 				if (isAdmin()) {
 					$action = 'if(confirm(\'' . __('sure-to-delete') . '\'))' . makeAction($this->language . '/' . $this->pagename, 'delete', '');
-					$button = makeButton(__('delete'), $action);
-					$commands->append($button);
+					$commands->append(makeButton(__('delete'), $action));
 				}
 			}
 
-			switch ($this->getArg(0)) {
-			/*
-				case 'translate':
-					return $this->translate();
-			*/
-				case 'settings':
-					return $this->showSettings();
-				case 'participants':
-					return $this->showParticipants();
-				case 'contributions':
-					return $this->showContributions();
-
-				case 'signup':
-					return $this->showSignup();
-				case 'confirm':
-					return $this->showConfirm();
-				case 'confirmation-needed':
-					return $this->showConfirmationNeeded();
-				case 'pay':
-					return $this->showPay();
-				case 'paymenthook':
-					return $this->handlePaymentHook();
-				case 'contribute':
-					return $this->showContribute();
-				case 'lineup':
-				case '':
-					return $this->showLineup();
-				case 'timetable':
-					return $this->showTimetable();
-				default:
-                                        return '404';
+			switch ([$request->getView(), $request->getCommand()]) {
+				case [null,                           null]:             return $this->lineupView($request);
+				case [null,                           self::CMD_DELETE]: return $this->deleteAction($request);
+				case [self::PATH_CONFIRMATION_NEEDED, null]:             return $this->confirmationNeededView($request);
+				case [self::PATH_CONFIRM,             null]:             return $this->confirmView($request);
+				case [self::PATH_CONTRIBUTE,          null]:             return $this->contributeView($request);
+				case [self::PATH_CONTRIBUTE,          self::CMD_SAVE]:   return $this->contributionSaveAction($request);
+				case [self::PATH_CONTRIBUTIONS,       null]:             return $this->contributionsView($request);
+				case [self::PATH_LINEUP,              null]:             return $this->lineupView($request);
+				case [self::PATH_PARTICIPANTS,        null]:             return $this->participantsView($request);
+				case [self::PATH_PAYMENTHOOK,         null]:             return $this->paymenthookView($request);
+				case [self::PATH_PAY,                 null]:             return $this->payView($request);
+				case [self::PATH_PAY,                 self::CMD_PAY]:    return $this->payAction($request);
+				case [self::PATH_SETTINGS,            null]:             return $this->settingsView($request);
+				case [self::PATH_SETTINGS,            self::CMD_SAVE]:   return $this->settingsSaveAction($request);
+				case [self::PATH_SIGNUP,              null]:             return $this->signupView($request);
+				case [self::PATH_SIGNUP,              self::CMD_SIGNUP]: return $this->signupAction($request);
+				case [self::PATH_TIMETABLE,           null]:             return $this->timetableView($request);
 			}
+
+			return '404';
 		}
 
 		public function getSortDateTime() {
@@ -110,7 +155,7 @@
 		 * attribute from it. If no attribute is given, the
 		 * "value" attribute is returned.
 		 */
-		function getConfig($id, $attribute = 'value') {
+		function getConfig($id, $attribute = self::CONFIG_ATTR_VALUE) {
 			$config = $this->getConfigElement($id);
 			if (!$config)
 				return '';
@@ -129,7 +174,7 @@
 			$elem = $this->xml->getElementById($id);
 			if (!$elem && $tagname) {
 				$elem = $this->xml->createElement($tagname);
-				$elem->setAttribute('xml:id', $id);
+				$elem->setId($id);
 				$this->xml->documentElement->appendChild($elem);
 			}
 			return $elem;
@@ -142,20 +187,15 @@
 		 * is set. If the tag does not exist, it is created,
 		 * using the given tagname.
 		 */
-		function setConfig($id, $value, $tagname = 'config', $attribute = 'value') {
+		function setConfig($id, $value, $tagname = self::CONFIG_TAG, $attribute = self::CONFIG_ATTR_VALUE) {
 			$config = $this->getConfigElement($id, $tagname);
 			return $config->setAttribute($attribute, $value);
-		}
-
-		function array_set_if_unset(&$array, $key, $default) {
-			if (!array_key_exists($key, $array))
-				$array[$key] = $default;
 		}
 
 		/**
 		 * Show the admin display with registrations.
 		 */
-		function showParticipants() {
+		function participantsView(HyphaRequest $request) {
 			if (!isUser()) return notify('error', __('login-to-edit'));
 
 			$stats = [];
@@ -164,22 +204,24 @@
 			$table = new HTMLTable();
 			$this->html->find('#main')->appendChild($table);
 			$table->addHeaderRow()->addCells([__('name'), __('email'), __('phone'), __('price'), __('festival-participant-status')]);
-			foreach ($this->xml->documentElement->getOrCreate('participants')->children() as $participant) {
-				$payamount = $participant->getAttribute('payment-amount');
+			foreach ($this->xml->documentElement->getOrCreate(self::TAG_PARTICIPANTS_CONTAINER)->children() as $participant) {
+				$payamount = $participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_AMOUNT);
 				if ($payamount)
-					$status = $participant->getAttribute('payment-status');
+					$status = $participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_STATUS);
 				else
-					$status = $participant->getAttribute('email-confirmed') ? 'confirmed' : 'unconfirmed';
+					$status = $participant->getAttribute(self::ATTR_PARTICIPANT_EMAIL_CONFIRMED) ? 'confirmed' : 'unconfirmed';
 
 				$row = $table->addRow();
-				$row->addCell($participant->getAttribute('name'));
-				$row->addCell($participant->getAttribute('email'));
-				$row->addCell($participant->getAttribute('phone'));
+				$row->addCell($participant->getAttribute(self::ATTR_PARTICIPANT_NAME));
+				$row->addCell($participant->getAttribute(self::ATTR_PARTICIPANT_EMAIL));
+				$row->addCell($participant->getAttribute(self::ATTR_PARTICIPANT_PHONE));
 				$row->addCell($payamount ? '€' . $payamount : '-');
 				$row->addCell($status);
 
 				$totalcount += 1;
-				$this->array_set_if_unset($stats, $status, ['paysum' => 0, 'count' => 0]);
+				if (!array_key_exists($status, $stats))
+						$stats[$status] = ['paysum' => 0, 'count' => 0];
+
 				$stats[$status]['count'] += 1;
 				if ($payamount) {
 					$stats[$status]['paysum'] += $payamount;
@@ -198,133 +240,193 @@
 			$row = $table->addRow();
 			$row->addCell(__('total'));
 			$row->addCell($totalcount);
+			return null;
 		}
 
 		/**
 		 * Show the admin display with contributions.
 		 */
-		function showContributions() {
+		function contributionsView(HyphaRequest $request) {
+			// TODO: Styling
 			if (!isUser()) return notify('error', __('login-to-edit'));
 			$table = new HTMLTable();
 			$this->html->find('#main')->appendChild($table);
+			$table->addClass('contributions');
 			$table->addHeaderRow()->addCells([__('name'), __('title'), __('category'), __('website')]);
-			foreach ($this->xml->documentElement->getOrCreate('contributions')->children() as $contribution) {
+			foreach ($this->xml->documentElement->getOrCreate(self::TAG_CONTRIBUTION_CONTAINER)->children() as $contribution) {
 				$row = $table->addRow();
-				$row->addCell($contribution->getAttribute('name'));
-				$row->addCell($contribution->getAttribute('title'));
-				$row->addCell($contribution->getAttribute('category'));
-				$row->addCell($contribution->getAttribute('website'));
+				$row->addCell($contribution->getAttribute(self::ATTR_CONTRIBUTION_NAME));
+				$row->addCell($contribution->getAttribute(self::ATTR_CONTRIBUTION_TITLE));
+				$row->addCell($contribution->getAttribute(self::ATTR_CONTRIBUTION_CATEGORY));
+				$row->addCell($contribution->getAttribute(self::ATTR_CONTRIBUTION_WEBSITE));
 
-				$action = makeAction($this->language.'/'.$this->pagename.'/contribute/'.$contribution->getAttribute('xml:id'), '', '');
-				$button = makeButton(__('edit'), $action);
+				$button = $this->makeActionButton(__('edit'), $this->pagename . '/' . self::PATH_CONTRIBUTE . '/'.$contribution->getId());
 				$row->addCell()->append($button);
 
-
-				$description = $contribution->getOrCreate('description')->text();
-				$imgfilename = $contribution->getAttribute('image');
+				$description = $contribution->getOrCreate(self::TAG_CONTRIBUTION_DESCRIPTION)->text();
+				$imgfilename = $contribution->getAttribute(self::ATTR_CONTRIBUTION_IMAGE);
 				if ($description || $imgfilename) {
 					$cell = $table->addRow()->addCell(__('description') . ': ' . $description);
 					$cell->setAttribute('colspan', 5);
-					$cell->setAttribute('style', 'padding-left: 50px;');
+					$cell->addClass('description');
 					if ($imgfilename) {
 						$imgtag = $this->html->createElement('img');
 						$cell->insertBefore($imgtag, $cell->firstChild);
-						$image = new HyphaImage($contribution->getAttribute('image'));
+						$image = new HyphaImage($contribution->getAttribute(self::ATTR_CONTRIBUTION_IMAGE));
 						$imgtag->setAttribute('src', $image->getUrl(50, 50));
-						$imgtag->setAttribute('style', 'float: left; margin: 5px 10px 0 0;');
 					}
 				}
-				$notes = $contribution->getOrCreate('notes')->text();
+				$notes = $contribution->getOrCreate(self::TAG_CONTRIBUTION_NOTES)->text();
 				if ($notes) {
 					$cell = $table->addRow()->addCell(__('notes') . ': ' . $notes);
 					$cell->setAttribute('colspan', 5);
-					$cell->setAttribute('style', 'padding-left: 50px;');
+					$cell->addClass('notes');
 				}
 			}
+			return null;
 		}
 
-
-		function getSettingsForm() {
-$html = <<<'EOF'
-<table>
-	<tr><td><label for="festival-title">Festival title</label> *</td><td><input id="festival-title" name="festival-title"/></td></tr>
-</table>
+		/**
+		 * @return HTMLForm
+		 */
+		function createSettingsForm(array $values=[]) {
+			$html = <<<EOF
+				<table>
+					<tr>
+						<td><label for="[[field-name-title]]">[[title]]</label></td>
+						<td><input id="[[field-name-title]]" name="[[field-name-title]]"/></td>
+					</tr>
+				</table>
 EOF;
-			return new HTMLForm($html);
+			$vars = [
+				'title' => __('festival-field-festival-title'),
+				'field-name-title' => self::FIELD_NAME_TITLE,
+			];
+
+			$html = hypha_substitute($html, $vars);
+
+			return new HTMLForm($html, $values);
 		}
 
-		function showSettings($form = null) {
+		function settingsView(HyphaRequest $request) {
 			if (!isUser()) return notify('error', __('login-to-edit'));
 
-			if (!$form) {
-				$form = $this->getSettingsForm();
-				$form->setData([
-					'festival-title' => $this->getConfig('festival-title'),
-				]);
-			}
+			// create form
+			$formData = [
+				self::FIELD_NAME_TITLE => $this->getConfig(self::CONFIG_ID_TITLE),
+			];
 
+			$form = $this->createSettingsForm($formData);
+			return $this->settingsViewRender($request, $form);
+		}
+
+		function settingsViewRender($request, $form) {
+			// Update the form to include the data
 			$form->updateDom();
+
 			$this->html->find('#main')->append($form);
 
-			// show 'cancel' button
-			$action = makeAction($this->language.'/'.$this->pagename, '', '');
-			$button = makeButton(__('cancel'), $action);
-			$this->html->writeToElement('pageCommands', $button);
-
-			// show 'save' button
-			$action = makeAction($this->language.'/'.$this->pagename, 'save', '');
-			$button = makeButton(__('save'), $action);
-			$this->html->writeToElement('pageCommands', $button);
+			$commands = $this->html->find('#pageCommands');
+			$commands->append($this->makeActionButton(__('save'), self::PATH_SETTINGS, self::CMD_SAVE));
+			$commands->append($this->makeActionButton(__('cancel'), ''));
+			return null;
 		}
 
-		function handleSaveSettings($arg) {
-			global $hyphaPage;
-
+		function settingsSaveAction(HyphaRequest $request) {
 			if (!isUser()) return notify('error', __('login-to-edit'));
-			$form = $this->getSettingsForm();
-			$form->setData($_POST);
-			$form->validateRequiredField('festival-title');
 
-			if ($form->errors) {
-				// HACK: Prevent index.php from
-				// rendering the page normally, since we
-				// already rendered it. There should be
-				// a better way to achive this.
-				$hyphaPage = false;
-				return $this->showSettings($form);
-			}
+			// create form
+			$form = $this->createSettingsForm($request->getPostData());
+
+			$form->validateRequiredField(self::FIELD_NAME_TITLE);
+
+			// process form if it was posted
+			if (!empty($form->errors))
+				return $this->settingsViewRender($request, $form);
+
 			$this->xml->lockAndReload();
-			$this->setConfig('festival-title', $form->dataFor('festival-title'));
+			$this->setConfig(self::CONFIG_ID_TITLE, $form->dataFor(self::FIELD_NAME_TITLE));
 			$this->xml->saveAndUnlock();
-			return 'reload';
+
+			notify('success', ucfirst(__('festival-settings-saved')));
+			return ['redirect', $this->constructFullPath($this->pagename)];
 		}
 
-		function handleDelete() {
-			// throw error if delete is requested without admin logged in
+		function deleteAction(HyphaRequest $request) {
 			if (!isAdmin()) return notify('error', __('login-as-admin-to-delete'));
-
-			global $hyphaUrl;
 
 			$this->deletePage();
 
 			notify('success', ucfirst(__('page-successfully-deleted')));
-			return ['redirect', $hyphaUrl];
+			return ['redirect', $request->getRootUrl()];
+		}
+
+		/**
+		 * Create a signup form, based on the one configured.
+		 */
+		private function createSignupForm(array $values = []) {
+			$html = $this->getConfigElement(self::CONFIG_ID_SIGNUP_FORM, self::CONFIG_TAG_FORM)->children();
+
+			if ($html->count() == 0) {
+				$html = <<<EOF
+					<table class="festivalForm">
+						<tr>
+							<th><label for="[[field-name-name]]">[[name]]</label></th>
+							<td><input type="text" name="[[field-name-name]]"></td>
+							<td>*</td>
+						</tr>
+						<tr>
+							<th><label for="[[field-name-email]]">[[email]]</label></th>
+							<td><input type="text" name="[[field-name-email]]"></td>
+							<td>*</td>
+						</tr>
+						<tr>
+							<th><label for="[[field-name-phone]]">[[phone]]</label></th>
+							<td><input type="text" name="[[field-name-phone]]"></td>
+							<td></td>
+						</tr>
+						<tr>
+							<th><label for="[[field-name-amount]]">[[amount]]</label></th>
+							<td><input type="text" name="[[field-name-amount]]"></td>
+							<td></td>
+						</tr>
+					</table>
+EOF;
+				$vars = [
+					'name' => __('festival-field-name'),
+					'field-name-name' => self::FIELD_NAME_NAME,
+					'email' => __('festival-field-email'),
+					'field-name-email' => self::FIELD_NAME_EMAIL,
+					'phone' => __('festival-field-phone'),
+					'field-name-phone' => self::FIELD_NAME_PHONE,
+					'amount' => __('festival-field-amount'),
+					'field-name-amount' => self::FIELD_NAME_AMOUNT,
+				];
+
+				$html = hypha_substitute($html, $vars);
+			}
+
+			return new HTMLForm($html, $values);
 		}
 
 		/**
 		 * The signup form. Here's where the fun starts.
 		 */
-		function showSignup($form = null) {
-			if (!$form)
-				$form = new HTMLForm($this->getConfigElement('signup-form')->children());
+		function signupView(HyphaRequest $request) {
+			$form = $this->createSignupForm();
+			return $this->signupViewRender($request, $form);
+		}
 
-			$this->html->find('#pagename')->text(__('festival-signup-for') . $this->getConfig('festival-title'));
-			$main = $this->html->find('#main');
-			$main->append($form);
+		function signupViewRender(HyphaRequest $request, HTMLForm $form) {
+			$form->updateDom();
 
-			$action = makeAction($this->language.'/'.$this->pagename, 'signup', '');
-			$button = makeButton(__('signup'), $action);
-			$main->append($button);
+			$this->html->find('#main')->append($form);
+			$this->html->find('#pagename')->text(__('festival-signup-for') . $this->getConfig(self::CONFIG_ID_TITLE));
+
+			$commands = $this->html->find('#pageEndCommands');
+			$commands->append($this->makeActionButton(__('signup'), self::PATH_SIGNUP, self::CMD_SIGNUP));
+
+			return null;
 		}
 
 		/**
@@ -332,54 +434,50 @@ EOF;
 		 * /contribute, depending on whether there is something to
 		 * pay.
 		 */
-		function handleSignup($arg) {
-			global $hyphaUrl, $hyphaContentLanguage, $hyphaPage;
-			$form = new HTMLForm($this->getConfigElement('signup-form')->children());
-			$form->setData($_POST);
-			$form->validateRequiredField('name');
-			$form->validateRequiredField('email');
-			$form->validateEmailField('email');
-			$form->validateMoneyField('amount');
-			if ($form->errors) {
-				// HACK: Prevent index.php from
-				// rendering the page normally, since we
-				// already rendered it. There should be
-				// a better way to achieve this.
-				$hyphaPage = false;
-				// Reshow the form with submitted values
-				// and errors
-				$form->updateDom();
-				return $this->showSignup($form);
-			}
+		function signupAction(HyphaRequest $request) {
+			// create form
+			$form = $this->createSignupForm($request->getPostData());
+
+			$form->validateRequiredField(self::FIELD_NAME_NAME);
+			$form->validateRequiredField(self::FIELD_NAME_EMAIL);
+			$form->validateEmailField(self::FIELD_NAME_EMAIL);
+			$form->validateMoneyField(self::FIELD_NAME_AMOUNT);
+
+			if (!empty($form->errors))
+				return $this->signupViewRender($request, $form);
 
 			$this->xml->lockAndReload();
 
-			$participant = $this->xml->createElement('participant');
+			$participant = $this->xml->createElement(self::TAG_PARTICIPANT);
 			$participant->generateId();
-			$participant->setAttribute('name', $form->dataFor('name'));
-			$participant->setAttribute('email', $form->dataFor('email'));
-			$participant->setAttribute('phone', $form->dataFor('phone'));
-			$participant->setAttribute('key', bin2hex(openssl_random_pseudo_bytes(8)));
-			$this->xml->documentElement->getOrCreate('participants')->append($participant);
-			if ((float)$form->dataFor('amount', 0) > 0)
-				$this->setupPayment($participant, $form->dataFor('amount', 0));
+			$participant->setAttribute(self::ATTR_PARTICIPANT_NAME, $form->dataFor(self::FIELD_NAME_NAME));
+			$participant->setAttribute(self::ATTR_PARTICIPANT_EMAIL, $form->dataFor(self::FIELD_NAME_EMAIL));
+			$participant->setAttribute(self::ATTR_PARTICIPANT_PHONE, $form->dataFor(self::FIELD_NAME_PHONE));
+			$participant->setAttribute(self::ATTR_PARTICIPANT_KEY, bin2hex(openssl_random_pseudo_bytes(8)));
+			$this->xml->documentElement->getOrCreate(self::TAG_PARTICIPANTS_CONTAINER)->append($participant);
+			if ((float)$form->dataFor(self::FIELD_NAME_AMOUNT, 0) > 0)
+				$this->setupPayment($participant, $form->dataFor(self::FIELD_NAME_AMOUNT, 0));
 			$this->xml->saveAndUnlock();
 
-			notify('success', __('festival-successful-signup-for') . $this->getConfig('festival-title'));
-			$contribute_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/contribute/' . $participant->getAttribute('xml:id') . '/' . $participant->getAttribute('key');
-			$digest = htmlspecialchars($participant->getAttribute('name') . __('festival-signed-up-for') . $this->getConfig('festival-title'));
-			$digest .= ' (<a href="' . $contribute_url . '">Add contribution</a>)';
+			notify('success', __('festival-successful-signup-for') . $this->getConfig(self::CONFIG_ID_TITLE));
+			$contribute_url = $this->constructFullPath($this->pagename . '/' . self::PATH_CONTRIBUTE . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
+			$digest = htmlspecialchars($participant->getAttribute(self::ATTR_PARTICIPANT_NAME) . __('festival-signed-up-for') . $this->getConfig(self::CONFIG_ID_TITLE));
+			$digest .= ' (<a href="' . htmlspecialchars($contribute_url) . '">Add contribution</a>)';
 			writeToDigest($digest, 'festival-registration');
 
-			if ((float)$form->dataFor('amount', 0) > 0) {
-				$next_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/pay/' . $participant->getAttribute('xml:id') . '/' . $participant->getAttribute('key');
+			if ((float)$form->dataFor(self::FIELD_NAME_AMOUNT, 0) > 0) {
+				$next_url = $this->constructFullPath($this->pagename . '/' . self::PATH_PAY . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
 			} else {
-				$next_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/confirmation-needed';
+				$next_url = $this->constructFullPath($this->pagename . '/confirmation-needed');
 
 				// Send email
-				$confirm_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/confirm/' . $participant->getAttribute('xml:id') . '/' . $participant->getAttribute('key');
-				$append = '<p><a href="'.htmlspecialchars($confirm_url).'">'.__('festival-confirm-email') . '</a></p>';
-				$this->sendMail($participant->getAttribute('email'), 'mail-confirm-email', $append);
+				$confirm_url = $this->constructFullPath($this->pagename . '/' . self::PATH_CONFIRM . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
+				$vars = [
+					'festival-title' => $this->getConfig(self::CONFIG_ID_TITLE),
+					'confirmlink' => $confirm_url,
+				];
+				$rcpt = $participant->getAttribute(self::ATTR_PARTICIPANT_EMAIL);
+				$this->sendMail($rcpt, 'festival-confirm-registration', $vars);
 			}
 			return ['redirect', $next_url];
 		}
@@ -388,46 +486,49 @@ EOF;
 		 * For unpaid registrations, show a message that
 		 * confirmation is needed.
 		 */
-		function showConfirmationNeeded() {
+		function confirmationNeededView(HyphaRequest $request) {
 			$this->html->find('#pagename')->text(__('festival-confirmation-needed'));
 			$main = $this->html->find('#main');
 			$message = __('festival-complete-by-confirming');
 			$main->append($message);
+			return null;
 		}
 
 		/**
 		 * For unpaid registrations, this link needs to be
 		 * clicked to confirm the registration.
 		 */
-		function showConfirm() {
-			global $hyphaUrl, $hyphaContentLanguage;
-
+		function confirmView(HyphaRequest $request) {
 			$this->xml->lockAndReload();
-			$participant = $this->checkKeyArguments(['participant']);
+			$participant = $this->checkKeyArguments($request, [self::TAG_PARTICIPANT]);
 			if (!$participant) {
 				$this->xml->unlock();
-				return;
+				return '404';
 			}
-			$contribute_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/contribute/' . $participant->getAttribute('xml:id') . '/' . $participant->getAttribute('key');
+			$contribute_url = $this->constructFullPath($this->pagename . '/' . self::PATH_CONTRIBUTE . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
 
-			if ($participant->getAttribute('email-confirmed')) {
+			if ($participant->getAttribute(self::ATTR_PARTICIPANT_EMAIL_CONFIRMED)) {
 				$this->xml->unlock();
 				notify('success', __('festival-email-already-confirmed'));
 			} else {
 				notify('success', __('festival-email-confirmed-successfully'));
 
 				// Mark e-mail as confirmed
-				$participant->setAttribute('email-confirmed', '1');
+				$participant->setAttribute(self::ATTR_PARTICIPANT_EMAIL_CONFIRMED, '1');
 				$this->xml->saveAndUnlock();
 
 				// Note in digest
-				$digest = htmlspecialchars($participant->getAttribute('name') . __('festival-confirmed-for') . $this->getConfig('festival-title'));
+				$digest = htmlspecialchars($participant->getAttribute(self::ATTR_PARTICIPANT_NAME) . __('festival-confirmed-for') . $this->getConfig(self::CONFIG_ID_TITLE));
 				$digest .= ' (<a href="' . $contribute_url . '">Add contribution</a>)';
 				writeToDigest($digest, 'festival-confirmation');
 
-				// Send e-mail
-				$append = '<p><a href="'.htmlspecialchars($contribute_url).'">'.__('festival-contribute') . '</a></p>';
-				$this->sendMail($participant->getAttribute('email'), 'mail-signed-up-free', $append);
+				// Send email
+				$vars = [
+					'festival-title' => $this->getConfig(self::CONFIG_ID_TITLE),
+					'contributelink' => $contribute_url,
+				];
+				$rcpt = $participant->getAttribute(self::ATTR_PARTICIPANT_EMAIL);
+				$this->sendMail($rcpt, 'festival-registration-confirmed', $vars);
 			}
 
 			// Redirect to contribution page
@@ -440,32 +541,29 @@ EOF;
 		 * is already complete, this redirects to the
 		 * /contribute page.
 		 */
-		function showPay() {
-			global $hyphaUrl, $hyphaContentLanguage;
-
+		function payView(HyphaRequest $request) {
 			$this->xml->lockAndReload();
-			$participant = $this->checkKeyArguments(['participant']);
+			$participant = $this->checkKeyArguments($request, [self::TAG_PARTICIPANT]);
 			if (!$participant) {
 				$this->xml->unlock();
-				return;
+				return null;
 			}
 
 			// Check the status of the payment
 			$this->checkPayment($participant);
 			$this->xml->saveAndUnlock();
 
-			if ($participant->getAttribute('payment-timestamp')) {
-				$url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/contribute/' . $participant->getAttribute('xml:id') . '/' . $participant->getAttribute('key');
+			if ($participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_TIMESTAMP)) {
+				$url = $this->constructFullPath($this->pagename . '/' . self::PATH_CONTRIBUTE . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
 				notify('success', __('festival-successful-payment'));
 				return ['redirect', $url];
 			}
 
 			// Render the page
-			$this->html->find('#pagename')->text(__('festival-pay-for') . $this->getConfig('festival-title'));
+			$this->html->find('#pagename')->text(__('festival-pay-for') . $this->getConfig(self::CONFIG_ID_TITLE));
 			$main = $this->html->find('#main');
 			$message = __('festival-complete-by-paying');
-			$action = makeAction($this->language.'/'.$this->pagename.'/'.join('/',$this->args), 'pay', '');
-			$button = makeButton(__('pay'), $action);
+			$button = $this->makeActionButton(__('pay'), join('/',$request->getArgs()), self::CMD_PAY);
 			$main->append($message);
 			$main->append($button);
 		}
@@ -476,13 +574,12 @@ EOF;
 		 * the payment was already completed, then it redirects
 		 * to the /contribute page.
 		 */
-		function handlePay() {
-			global $hyphaUrl, $hyphaContentLanguage;
+		function payAction(HyphaRequest $request) {
 			$this->xml->lockAndReload();
-			$participant = $this->checkKeyArguments(['participant']);
+			$participant = $this->checkKeyArguments($request, [self::TAG_PARTICIPANT]);
 			if(!$participant) {
 				$this->xml->unlock();
-				return;
+				return null;
 			}
 
 			// Check the status of the payment, and create a
@@ -494,21 +591,27 @@ EOF;
 			// contribute page. Otherwise, redirect to
 			// payment provider.
 			if (!$url)
-				$url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/contribute/' . $participant->getAttribute('xml:id') . '/' . $participant->getAttribute('key');
+				$url = $this->constructFullPath($this->pagename . '/' . self::PATH_CONTRIBUTE . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
 
 			return ['redirect', $url];
 		}
 
-		function handlePaymentHook() {
+		function paymenthookView(HyphaRequest $request) {
 			$this->xml->lockAndReload();
-			$participant = $this->checkKeyArguments(['participant']);
+			$participant = $this->checkKeyArguments($request, [self::TAG_PARTICIPANT]);
 			if(!$participant) {
+				// We need to return 403 to prevent
+				// rewrites by the payment provider.
+				// TODO: 403 in a more generic place?
 				http_response_code(403);
 				writeToDigest('Invalid participant id or key in payment hook: ' . $_SERVER['REQUEST_URI'] . '?' . $_SERVER['QUERY_STRING'], 'error');
 				exit;
 			}
 
-			if($participant->getAttribute('payment-id') != $_REQUEST['id']) {
+			if($participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_ID) != $_REQUEST['id']) {
+				// We need to return 403 to prevent
+				// rewrites by the payment provider.
+				// TODO: 403 in a more generic place?
 				http_response_code(403);
 				writeToDigest('Invalid payment id in payment hook: ' . $_SERVER['REQUEST_URI'] . '?' . $_SERVER['QUERY_STRING'], 'error');
 				exit;
@@ -523,115 +626,202 @@ EOF;
 			exit;
 		}
 
+		private function createContributionForm(array $values = []) {
+			$html = $this->getConfigElement(self::CONFIG_ID_CONTRIBUTION_FORM, self::CONFIG_TAG_FORM)->children();
+
+			if ($html->count() == 0) {
+				$html = <<<EOF
+					<table class="festivalForm">
+						<tr>
+							<th><label for="[[field-name-name]]">[[name]]</label></th>
+							<td><input type="text" name="[[field-name-name]]"/></td>
+							<td>*</td>
+						</tr>
+						<tr>
+							<th><label for="[[field-name-title]]">[[title]]</label></th>
+							<td><input type="text" name="[[field-name-title]]"/></td>
+							<td>*</td>
+						</tr>
+						<tr>
+							<th><label for="[[field-name-description]]">[[description]]</label></th>
+							<td><textarea name="[[field-name-description]]"></textarea></td>
+							<td/>
+						</tr>
+							<tr><th><label for="[[field-name-image]]">[[image]]</label></th>
+							<td>
+								<input type="hidden" name="[[field-name-image]]"/>
+								<img data-preview-for="[[field-name-image]]"/><br/>
+								<input type="file" name="[[field-name-image-upload]]"/>
+							</td>
+							<td/>
+						</tr>
+						<tr>
+							<th><label for="[[field-name-website]]">[[website]]</label></th>
+							<td><input type="text" name="[[field-name-website]]"/></td>
+							<td/>
+						</tr>
+						<tr>
+							<th><label for="[[field-name-category]]">[[category]]</label></th>
+							<td><select name="[[field-name-category]]">
+								<option disabled="disabled" selected="selected">select</option>
+								<option value="lecture">Lecture</option>
+								<option value="workshop">Workshop</option>
+								<option value="demonstration">Demonstration</option>
+								<option value="hackathon">Hackathon</option>
+								<option value="other">Other</option>
+							</select></td>
+							<td>*</td>
+						</tr>
+						<tr>
+							<th><label for="[[field-name-notes]]">[[notes]]</label></th>
+							<td><textarea name="[[field-name-notes]]"></textarea></td>
+							<td/>
+						</tr>
+					</table>
+EOF;
+				$vars = [
+					'name' => __('festival-field-contribution-name'),
+					'field-name-name' => self::FIELD_NAME_NAME,
+					'title' => __('festival-field-contribution-title'),
+					'field-name-title' => self::FIELD_NAME_TITLE,
+					'description' => __('festival-field-contribution-description'),
+					'field-name-description' => self::FIELD_NAME_DESCRIPTION,
+					'image' => __('festival-field-contribution-image'),
+					'field-name-image' => self::FIELD_NAME_IMAGE,
+					'field-name-image-upload' => self::FIELD_NAME_IMAGE_UPLOAD,
+					'website' => __('festival-field-contribution-website'),
+					'field-name-website' => self::FIELD_NAME_WEBSITE,
+					'category' => __('festival-field-contribution-category'),
+					'field-name-category' => self::FIELD_NAME_CATEGORY,
+					'notes' => __('festival-field-contribution-notes'),
+					'field-name-notes' => self::FIELD_NAME_NOTES,
+
+				];
+
+				$html = hypha_substitute($html, $vars);
+			}
+
+			return new HTMLForm($html, $values);
+		}
+
 		/**
 		 * Show the contribution form.
 		 */
-		function showContribute($form = null, $editing = false) {
-			$obj = $this->checkKeyArguments(['contribution', 'participant'], true);
+		function contributeView(HyphaRequest $request) {
+			$obj = $this->checkKeyArguments($request, [self::TAG_CONTRIBUTION, self::TAG_PARTICIPANT], true);
 			if (!$obj)
-				return;
-			$editing = ($obj->tagName == 'contribution');
+				return '404';
 
-			if (!$form) {
-				$form = new HTMLForm($this->getConfigElement('contribution-form')->children());
-				if ($editing) {
-					$form->setData($obj);
-					$form->updateDom();
-				}
+			# If a contribution id is in the url, we're
+			# editing that contribution. If a participant id
+			# was passed, we are creating a new contribution.
+			$editing = ($obj->tagName == self::TAG_CONTRIBUTION);
+
+			$form = $this->createContributionForm();
+			if ($editing) {
+				// create form
+				$description = $obj->get(self::TAG_CONTRIBUTION_DESCRIPTION);
+				$notes = $obj->get(self::TAG_CONTRIBUTION_NOTES);
+				$formData = [
+					self::FIELD_NAME_NAME => $obj->getAttr(self::ATTR_CONTRIBUTION_NAME),
+					self::FIELD_NAME_TITLE => $obj->getAttr(self::ATTR_CONTRIBUTION_TITLE),
+					self::FIELD_NAME_CATEGORY => $obj->getAttr(self::ATTR_CONTRIBUTION_CATEGORY),
+					self::FIELD_NAME_IMAGE => $obj->getAttr(self::ATTR_CONTRIBUTION_IMAGE),
+					self::FIELD_NAME_WEBSITE => $obj->getAttr(self::ATTR_CONTRIBUTION_WEBSITE),
+					self::FIELD_NAME_DESCRIPTION => $description ? $description->text() : null,
+					self::FIELD_NAME_NOTES => $notes ? $notes->text() : null,
+				];
+
+				$form->setData($formData);
 			}
+			return $this->contributeViewRender($request, $form, $editing);
+		}
 
-			$this->html->find('#pagename')->text(__('festival-contribute-to') . $this->getConfig('festival-title'));
-			$main = $this->html->find('#main');
-			$main->append($form);
+		function contributeViewrender(HyphaRequest $request, HTMLForm $form, $editing) {
+			// Update the form to include any data
+			$form->updateDom();
 
-			$action = makeAction($this->language.'/'.$this->pagename.'/'.join('/',$this->args), 'contribute', '');
-			if ($editing)
-				$button = makeButton(__('festival-modify'), $action);
-			else
-				$button = makeButton(__('festival-contribute'), $action);
-			$main->append($button);
+			$this->html->find('#pagename')->text(__('festival-contribute-to') . $this->getConfig(self::CONFIG_ID_TITLE));
+			$this->html->find('#main')->append($form);
+
+			$commands = $this->html->find('#pageEndCommands');
+			$title = $editing ? __('festival-modify') : __('festival-contribute');
+			$commands->append($this->makeActionButton($title, join('/',$request->getArgs()), self::CMD_SAVE));
+			return null;
 		}
 
 		/**
 		 * Handle the contribution form.
 		 */
-		function handleContribute() {
-			global $hyphaUrl, $hyphaContentLanguage, $hyphaPage, $hyphaUser;
+		function contributionSaveAction(HyphaRequest $request) {
 			$this->xml->lockAndReload();
 
-			$obj = $this->checkKeyArguments(['contribution', 'participant'], true);
+			$obj = $this->checkKeyArguments($request, [self::TAG_CONTRIBUTION, self::TAG_PARTICIPANT], true);
 			if (!$obj)
-				return;
-			$errors = array();
+				return null;
 
-			$form = new HTMLForm($this->getConfigElement('contribution-form')->children());
-			$form->setData($_POST);
-			$form->validateRequiredField('name');
-			$form->validateRequiredField('title');
-			$form->validateRequiredField('category');
+			# If a contribution id is in the url, we're
+			# editing that contribution. If a participant id
+			# was passed, we are creating a new contribution.
+			$editing = ($obj->tagName == self::TAG_CONTRIBUTION);
+
+			$form = $this->createContributionForm($request->getPostData());
+
+			$form->validateRequiredField(self::FIELD_NAME_NAME);
+			$form->validateRequiredField(self::FIELD_NAME_TITLE);
+			$form->validateRequiredField(self::FIELD_NAME_CATEGORY);
 			if (array_key_exists('image_upload', $_FILES))
-				$form->handleImageUpload('image', $_FILES['image_upload']);
+				$form->handleImageUpload(self::FIELD_NAME_IMAGE, $_FILES['image_upload']);
 
-			if ($form->errors) {
+			if (!empty($form->errors)) {
 				$this->xml->unlock();
-				// HACK: Prevent index.php from
-				// rendering the page normally, since we
-				// already rendered it. There should be
-				// a better way to achive this.
-				$hyphaPage = false;
-				// Reshow the form with submitted values
-				// and errors
-				$form->updateDom();
-				return $this->showContribute($form);
+				return $this->contributeViewRender($request, $form, $editing);
 			}
 
 			// get contribution element or create new contribution element
-			if ($obj->tagName == 'contribution') {
+			if ($obj->tagName == self::TAG_CONTRIBUTION) {
 				$contribution = $obj;
-				$editing = true;
 			} else {
-				$contribution = $this->xml->createElement('contribution');
+				$contribution = $this->xml->createElement(self::TAG_CONTRIBUTION);
 				$contribution->generateId();
-				$contribution->setAttribute('key', bin2hex(openssl_random_pseudo_bytes(8)));
-				if ($obj ->tagName == 'participant')
-					$contribution->setAttribute('participant', $obj->getAttribute('xml:id'));
+				$contribution->setAttribute(self::ATTR_CONTRIBUTION_KEY, bin2hex(openssl_random_pseudo_bytes(8)));
+				if ($obj ->tagName == self::TAG_PARTICIPANT)
+					$contribution->setAttribute(self::ATTR_CONTRIBUTION_PARTICIPANT, $obj->getId());
 
-				$this->xml->documentElement->getOrCreate('contributions')->appendChild($contribution);
-				$editing = false;
+				$this->xml->documentElement->getOrCreate(self::TAG_CONTRIBUTION_CONTAINER)->appendChild($contribution);
 			}
 
 			// set attributes
-			$contribution->setAttribute('name', $form->dataFor('name'));
-			$contribution->setAttribute('title', $form->dataFor('title'));
-			$contribution->setAttribute('category', $form->dataFor('category'));
-			$contribution->setAttribute('image', $form->dataFor('image'));
+			$contribution->setAttribute(self::ATTR_CONTRIBUTION_NAME, $form->dataFor(self::FIELD_NAME_NAME));
+			$contribution->setAttribute(self::ATTR_CONTRIBUTION_TITLE, $form->dataFor(self::FIELD_NAME_TITLE));
+			$contribution->setAttribute(self::ATTR_CONTRIBUTION_CATEGORY, $form->dataFor(self::FIELD_NAME_CATEGORY));
+			$contribution->setAttribute(self::ATTR_CONTRIBUTION_IMAGE, $form->dataFor(self::FIELD_NAME_IMAGE));
+			$contribution->setAttribute(self::ATTR_CONTRIBUTION_WEBSITE, $form->dataFor(self::FIELD_NAME_WEBSITE));
 
-			$description = $contribution->getOrCreate('description');
-			$description->setText($form->dataFor('description', ''));
+			$description = $contribution->getOrCreate(self::TAG_CONTRIBUTION_DESCRIPTION);
+			$description->setText($form->dataFor(self::FIELD_NAME_DESCRIPTION, ''));
 
-			$contribution->setAttribute('website', $form->dataFor('website'));
-
-			$notes = $contribution->getOrCreate('notes');
-			$notes->setText($form->dataFor('notes', ''));
+			$notes = $contribution->getOrCreate(self::TAG_CONTRIBUTION_NOTES);
+			$notes->setText($form->dataFor(self::FIELD_NAME_NOTES, ''));
 
 			$this->xml->saveAndUnlock();
-			$edit_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/contribute/' . $contribution->getAttribute('xml:id') . '/' . $contribution->getAttribute('key');
+			$edit_url = $this->constructFullPath($this->pagename . '/' . self::PATH_CONTRIBUTE . '/' . $contribution->getId() . '/' . $contribution->getAttribute(self::ATTR_CONTRIBUTION_KEY));
 
 			if (isUser()) {
-				$name = htmlspecialchars(getNameForUser());
-				$email = $hyphaUser->getAttribute('email');
-			} else if ($participant_id = $contribution->getAttribute('participant')) {
-				$participant = $this->xml->getElementById($participant_id);
-				$name = htmlspecialchars($participant->getAttribute('name'));
-				$email = $participant->getAttribute('email');
+				$user = $this->O_O->getUser();
+				$name = getNameForUser($user);
+				$email = $user->getAttribute('email');
+			} else if ($obj ->tagName == self::TAG_PARTICIPANT) {
+				$name = $obj->getAttribute(self::ATTR_PARTICIPANT_NAME);
+				$email = $obj->getAttribute(self::ATTR_PARTICIPANT_EMAIL);
 			} else {
 				$name = __('anonymous');
 				$email = false;
 			}
 
 			$vars = [
-				'name' => $name,
-				'contribution'=> $contribution->getAttribute('title') . ' - ' . $contribution->getAttribute('name'),
+				'name' => htmlspecialchars($name),
+				'contribution'=> htmlspecialchars($contribution->getAttribute(self::ATTR_CONTRIBUTION_TITLE) . ' - ' . $contribution->getAttribute(self::ATTR_CONTRIBUTION_NAME)),
 			];
 			if ($editing)
 				$digest = __('festival-edited-contribution', $vars);
@@ -642,9 +832,15 @@ EOF;
 			writeToDigest($digest, 'festival-contribution');
 
 			if (!$editing && $email) {
-				$edit_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/contribute/' . $contribution->getAttribute('xml:id') . '/' . $contribution->getAttribute('key');
-				$append = '<p><a href="'.htmlspecialchars($edit_url).'">'.__('festival-edit-contribution') . '</a></p>';
-				$this->sendMail($email, 'mail-added-contribution', $append);
+				$edit_url = $this->constructFullPath($this->pagename . '/' . self::PATH_CONTRIBUTE . '/' . $contribution->getId() . '/' . $contribution->getAttribute(self::ATTR_CONTRIBUTION_KEY));
+
+				// Send email
+				$vars = [
+					'festival-title' => $this->getConfig(self::CONFIG_ID_TITLE),
+					'title' => $contribution->getAttribute(self::ATTR_CONTRIBUTION_TITLE),
+					'editlink' => $edit_url,
+				];
+				$this->sendMail($email, 'festival-contribution-added', $vars);
 			}
 
 			if ($editing)
@@ -652,20 +848,19 @@ EOF;
 			else
 				notify('success', __('festival-contribution-added'));
 
-			$lineup_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/lineup';
+			$lineup_url = $this->constructFullPath($this->pagename . '/lineup');
 			return ['redirect', $lineup_url];
 		}
 
 
-		function showLineup() {
-			global $hyphaHtml;
+		function lineupView(HyphaRequest $request) {
 			$html = '';
-			$contributions = $this->xml->documentElement->getOrCreate('contributions')->children();
+			$contributions = $this->xml->documentElement->getOrCreate(self::TAG_CONTRIBUTION_CONTAINER)->children();
 			foreach($contributions as $contribution) {
 				$html.= $this->buildContribution($contribution);
 				$html.= '<div class="hbar"></div>';
 			}
-			$this->html->find('#pagename')->text(__('festival-lineup-for') . $this->getConfig('festival-title'));
+			$this->html->find('#pagename')->text(__('festival-lineup-for') . $this->getConfig(self::CONFIG_ID_TITLE));
 			$this->html->find('#main')->html($html);
 		}
 
@@ -674,104 +869,83 @@ EOF;
 		 * lineup.
 		 */
 		function buildContribution($contribution) {
-			global $hyphaUrl, $hyphaContentLanguage;
-			$html = '<div class="infoact">';
-			// name and title
-			$id = $contribution->getAttribute('xml:id');
-			$url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/lineup#' . $id;
-			$editurl = $hyphaContentLanguage .'/'.$this->pagename.'/contribute/'.$contribution->getAttribute('xml:id');
+			$html = '<div class="contribution">';
+			// artist and title
+			$id = $contribution->getId();
+			$url = $this->constructFullPath($this->pagename . '/lineup#' . $id);
+			$editurl = $this->constructFullPath($this->pagename.'/' . self::PATH_CONTRIBUTE . '/'.$contribution->getId());
 
 			$title = '';
-			if ($contribution->getAttribute('category'))
-				$title .= $contribution->getAttribute('category') . ': ';
-			if ($contribution->getAttribute('name'))
-				$title .= $contribution->getAttribute('name');
-			if ($contribution->getAttribute('name') && $contribution->getAttribute('title'))
+			if ($contribution->getAttribute(self::ATTR_CONTRIBUTION_CATEGORY))
+				$title .= $contribution->getAttribute(self::ATTR_CONTRIBUTION_CATEGORY) . ': ';
+			if ($contribution->getAttribute(self::ATTR_CONTRIBUTION_NAME))
+				$title .= $contribution->getAttribute(self::ATTR_CONTRIBUTION_NAME);
+			if ($contribution->getAttribute(self::ATTR_CONTRIBUTION_NAME) && $contribution->getAttribute(self::ATTR_CONTRIBUTION_TITLE))
 				$title .= ' - ';
-			if ($contribution->getAttribute('title'))
-				$title .= $contribution->getAttribute('title');
+			if ($contribution->getAttribute(self::ATTR_CONTRIBUTION_TITLE))
+				$title .= $contribution->getAttribute(self::ATTR_CONTRIBUTION_TITLE);
 
-			$html.= '<a id="'.$id.'" href="'.$url.'" style="font-size:15pt; font-weight:bold; clear:left;">'.$title.'</a>';
+			$html.= '<h2 id="'.htmlspecialchars($id).'"><a href="'.htmlspecialchars($url).'">'.htmlspecialchars($title).'</a>';
 			if (isUser())
 				$html.= ' (<a class="edit" href="'.$editurl.'">'.__('festival-edit-contribution').'</a>)';
-			$html.= '<p/>';
+			$html.= '</h2>';
+
 			// image and description
-			$image_filename = $contribution->getAttribute('image');
+			$image_filename = $contribution->getAttribute(self::ATTR_CONTRIBUTION_IMAGE);
 			if ($image_filename) {
 				$img_width = 150;
 				$img_height = 150;
 				$image = new HyphaImage($image_filename);
-				$html.= '<a href="'.$image->getUrl().'"><img style="float:left; border:0px; margin-right:10px;" src="'.$image->getUrl($img_width, $img_height).'"/></a>';
+				$html.= '<a href="'.htmlspecialchars($image->getUrl()).'"><img src="'.htmlspecialchars($image->getUrl($img_width, $img_height)).'"/></a>';
 			}
-			$description = $contribution->getElementsByTagName('description')->Item(0);
+			$description = $contribution->getElementsByTagName(self::TAG_CONTRIBUTION_DESCRIPTION)->Item(0);
 			if ($description) $html.= nl2br(htmlspecialchars($description->text()));
-			$html.= '<p style="clear:left;"/>';
-			// icons
-			$html.= '<div style="float:right; padding-top:5px; padding-left:5px;">';
-			foreach($contribution->getElementsByTagName('icon') as $icon) {
-				$html.= '<a href="'.$icon->getAttribute('website').'"><img style="border:0px;" src="images/'.$icon->getAttribute('source').'"/></a>';
-			}
-			$html.= '</div>';
 
-			$days = $this->getConfigElement('days', 'config')->children();
-			$locations = $this->getConfigElement('locations', 'config')->children();
+			$days = $this->getConfigElement(self::CONFIG_ID_DAYS, self::CONFIG_TAG_DAYS)->children();
+			$locations = $this->getConfigElement(self::CONFIG_ID_LOCATIONS, self::CONFIG_TAG_LOCATIONS)->children();
 			foreach($days as $day) {
 				$timesHtml = '';
-				foreach($contribution->getElementsByTagName('event') as $event) {
-					if ($event->getAttribute('day') == $day->getId()) {
-						if ($event->getAttribute('begin')) {
-							$timesHtml .= '&#160;&#160;&#160;'.$event->getAttribute('begin').'-'.$event->getAttribute('end');
-							foreach($locations as $location) if ($location->getId() == $event->getAttribute('location')) {
-								$timesHtml.= ', '.$location->getAttribute('display');
+				foreach($contribution->getElementsByTagName(self::TAG_CONTRIBUTION_EVENT) as $event) {
+					if ($event->getAttribute(self::ATTR_EVENT_DAY) == $day->getId()) {
+						if ($event->getAttribute(self::ATTR_EVENT_BEGIN)) {
+							$timesHtml .= '<div class="time-and-place">'.htmlspecialchars($event->getAttribute(self::ATTR_EVENT_BEGIN).'-'.$event->getAttribute(self::ATTR_EVENT_END));
+							foreach($locations as $location) if ($location->getId() == $event->getAttribute(self::ATTR_EVENT_LOCATION)) {
+								$timesHtml.= ', '.htmlspecialchars($location->getAttribute(self::ATTR_LOCATION_DISPLAY));
 							}
-							$timesHtml.='<br/>';
+							$timesHtml .= '</div>';
 						}
 					}
 				}
-				if ($timesHtml) $html.= '<b>'.$day->getAttribute('display').'</b><br/>'.$timesHtml;
+				if ($timesHtml) $html.= '<div class="event"><div class="date">'.htmlspecialchars($day->getAttribute(self::ATTR_DAY_DISPLAY)).'</div>'.$timesHtml;
 			}
-			// price and duration
-			if ($contribution->hasAttribute('price') || $contribution->hasAttribute('duration')) {
-				$price = $contribution->hasAttribute('price') && $contribution->getAttribute('price') ? __('price').': '.$contribution->getAttribute('price') : '';
-				$duration = $contribution->hasAttribute('duration') && $contribution->getAttribute('duration') ? $contribution->getAttribute('duration') : '';
-				$html.= '<b>'.$price.($price && $duration ? ' | ' : '').$duration.'</b><br/>';
-			}
-			$website = htmlspecialchars($contribution->getAttribute('website'));
+			$website = htmlspecialchars($contribution->getAttribute(self::ATTR_CONTRIBUTION_WEBSITE));
 			if ($website)
-				$html.= "<a href=\"$website\">$website</a>";
-			// additional urls
-			foreach($contribution->getElementsByTagName('contact') as $contact) {
-				if ($contact->hasAttribute('website') && $contact->getAttribute('website')) $html.= '<a style="text-decoration: none;color:#d2691e;" href="'.$contact->getAttribute('website').'">'.$contact->getAttribute('website').'</a>';
-			}
+				$html.= "<div class=\"website\"><a href=\"$website\">$website</a></div>";
 			$html.= '</div>';
-			$html.= '<p style="clear:right;"/>';
 
 			return $html;
 		}
 
-		function showTimetable() {
-			global $hyphaHtml, $hyphaContentLanguage, $hyphaUrl;
-
+		function timetableView(HyphaRequest $request) {
 			// Make a list of all days, and per day all
 			// locations and the begin and end time.
-			$contributions = $this->xml->documentElement->getOrCreate('contributions')->children();
-			$days = $this->getConfigElement('days', 'config')->children();
-			$locations = $this->getConfigElement('locations', 'config')->children();
+			$contributions = $this->xml->documentElement->getOrCreate(self::TAG_CONTRIBUTION_CONTAINER)->children();
+			$days = $this->getConfigElement(self::CONFIG_ID_DAYS, self::CONFIG_TAG_DAYS)->children();
+			$locations = $this->getConfigElement(self::CONFIG_ID_LOCATIONS, self::CONFIG_TAG_LOCATIONS)->children();
 
 			// iterate over all dates
 			$html = '';
 			$d = 0;
 			foreach($days as $day) {
-				// TODO: If begin and end not set, autodetect?
-				$daybegin = $day->getAttribute('begin');
-				$dayend = $day->getAttribute('end');
+				$daybegin = $day->getAttribute(self::ATTR_DAY_BEGIN);
+				$dayend = $day->getAttribute(self::ATTR_DAY_END);
 
 				foreach($contributions as $contribution) {
-					$events = $contribution->getElementsByTagName('event');
+					$events = $contribution->getElementsByTagName(self::TAG_CONTRIBUTION_EVENT);
 					foreach($events as $event) {
-						$eventday = $event->getAttribute('day');
-						$eventbegin = $event->getAttribute('begin');
-						$eventend = $event->getAttribute('end');
+						$eventday = $event->getAttribute(self::ATTR_EVENT_DAY);
+						$eventbegin = $event->getAttribute(self::ATTR_EVENT_BEGIN);
+						$eventend = $event->getAttribute(self::ATTR_EVENT_END);
 						if ($eventbegin && $eventend && $eventday == $day->getId()) {
 							if (!$daybegin || $eventbegin < $daybegin)
 								$daybegin = $eventbegin;
@@ -782,7 +956,7 @@ EOF;
 				}
 
 				// output date header
-				$html.= '<br/><br/><h1>'.$day->getAttribute('display').'</h1><br/>';
+				$html.= '<br/><br/><h1>'.$day->getAttribute(self::ATTR_DAY_DISPLAY).'</h1><br/>';
 				$html.= "<table class=\"festivalTimetable\">";
 
 				// output row of invisible images to force a more or less regular time grid
@@ -800,10 +974,16 @@ EOF;
 					// generate a list of events for the given date and location
 					$locevents = [];
 					foreach($contributions as $contribution) {
-						$events = $contribution->getElementsByTagName('event');
+						$events = $contribution->getElementsByTagName(self::TAG_CONTRIBUTION_EVENT);
 						foreach($events as $event) {
-							if ($event->getAttribute('day') == $day->getId() && $event->getAttribute('location') == $location->getId())
-								$locevents[] = [$this->timetocols($daybegin, $event->getAttribute('begin')), $this->timetocols($daybegin, $event->getAttribute('end')), $contribution->getAttribute('name'), $contribution->getId(), $contribution->getAttribute('title')];
+							if ($event->getAttribute(self::ATTR_EVENT_DAY) == $day->getId() && $event->getAttribute(self::ATTR_EVENT_LOCATION) == $location->getId())
+								$locevents[] = [
+									$this->timetocols($daybegin, $event->getAttribute(self::ATTR_EVENT_BEGIN)),
+									$this->timetocols($daybegin, $event->getAttribute(self::ATTR_EVENT_END)),
+									$contribution->getAttribute(self::ATTR_CONTRIBUTION_NAME),
+									$contribution->getId(),
+									$contribution->getAttribute(self::ATTR_CONTRIBUTION_TITLE),
+								];
 						}
 					}
 
@@ -833,16 +1013,13 @@ EOF;
 						// output events
 						$id = 'a'.$d.'_'.$l;
 						$html.= '<tr class="'.($line%2 ? 'tableRowOdd' : 'tableRowEven').'">';
-						$html.= '<td id="'.$id.'" class="hover tableRowHeading '.($line%2 ? 'tableRowHeadingOdd' : 'tableRowHeadingEven').'" >'.$location->getAttribute('display').'</td>';
-						//$html.= '<td id="'.$id.'" class="hover tableRowHeading '.($line%2 ? 'tableRowHeadingOdd' : 'tableRowHeadingEven').'" onmouseover="showhide(\''.$id.'\',100,-10,\'location\',\''.$location->getAttribute('id').'\');" onmouseout="showhide();">'.$location->getAttribute('name').'</td>';
-						$t = $daybegin;
+						$html.= '<td id="'.$id.'" class="hover tableRowHeading '.($line%2 ? 'tableRowHeadingOdd' : 'tableRowHeadingEven').'" >'.$location->getAttribute(self::ATTR_LOCATION_DISPLAY).'</td>';
 						$t = 0;
 						for ($r=0; $r<count($row); $r++) {
 							$timeslot = $row[$r];
 							$id = "a".$d.'_'.$l.'_'.$r;
 							if ($timeslot[0] - $t) $html.= '<td class="'.($line%2 ? 'tableRowOdd' : 'tableRowEven').'" colspan="'.($timeslot[0] - $t).'"></td>';
-							//$html.= '<td id="'.$id.'" class="hover tableAct '.($line%2 ? 'tableRowOddAct' : 'tableRowEvenAct').'" colspan="'.($timeslot[1] - $timeslot[0]).'" onmouseover="showhide(\''.$id.'\',-120,0,\'act\',\''.$timeslot[3].'\');" onmouseout="showhide();">'.$timeslot[2];
-							$lineup_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/lineup';
+							$lineup_url = $this->constructFullPath($this->pagename . '/lineup');
 							$html.= '<td id="'.$id.'" class="hover tableAct '.($line%2 ? 'tableRowOddAct' : 'tableRowEvenAct').'" colspan="'.($timeslot[1] - $timeslot[0]).'"><a href="'.htmlspecialchars($lineup_url).'#'.htmlspecialchars($timeslot[3]).'">'.htmlspecialchars($timeslot[2]);
 							if ($timeslot[2] && $timeslot[4]) $html.= ' - ';
 							$html.= '<i>'.$timeslot[4].'</i></a></td>';
@@ -857,7 +1034,7 @@ EOF;
 				$html.= '</table>';
 				$d++;
 			}
-			$this->html->find('#pagename')->text(__('festival-timetable-for') . $this->getConfig('festival-title'));
+			$this->html->find('#pagename')->text(__('festival-timetable-for') . $this->getConfig(self::CONFIG_ID_TITLE));
 			$this->html->find('#main')->html($html);
 		}
 
@@ -874,8 +1051,8 @@ EOF;
 		 */
 		function setupPayment($participant, $amount) {
 			$participant->ownerDocument->requireLock();
-			$participant->setAttribute('payment-description', $this->getConfig('festival-title') . ' - ' . $participant->getAttribute('name'));
-			$participant->setAttribute('payment-amount', $amount);
+			$participant->setAttribute(self::ATTR_PARTICIPANT_PAYMENT_DESCRIPTION, $this->getConfig(self::CONFIG_ID_TITLE) . ' - ' . $participant->getAttribute(self::ATTR_PARTICIPANT_NAME));
+			$participant->setAttribute(self::ATTR_PARTICIPANT_PAYMENT_AMOUNT, $amount);
 			// Create a payment right away. This ensures
 			// that even if the user never clicks the
 			// payment button, this payment will expire and
@@ -891,10 +1068,9 @@ EOF;
 		 * Should be called with the XML lock held.
 		 */
 		function createPayment($participant) {
-			global $hyphaUrl, $hyphaContentLanguage;
 			$participant->ownerDocument->requireLock();
-			$complete_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/pay/' . $participant->getAttribute('xml:id') . '/' . $participant->getAttribute('key');
-			$hook_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/paymenthook/' . $participant->getAttribute('xml:id') . '/' . $participant->getAttribute('key');
+			$complete_url = $this->constructFullPath($this->pagename . '/' . self::PATH_PAY . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
+			$hook_url = $this->constructFullPath($this->pagename . '/' . self::PATH_PAYMENTHOOK . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
 
 			// load Mollie script
 			require_once('system/Mollie/API/Autoloader.php');
@@ -903,14 +1079,14 @@ EOF;
 
 			// create payment
 			$payment = $mollie->payments->create([
-				"amount"       => $participant->getAttribute('payment-amount'),
-				"description"  => $participant->getAttribute('payment-description'),
+				"amount"       => $participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_AMOUNT),
+				"description"  => $participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_DESCRIPTION),
 				"redirectUrl"  => $complete_url,
 				"webhookUrl"   => $hook_url,
 			]);
 
-			$participant->setAttribute('payment-id', $payment->id);
-			$participant->setAttribute('payment-status', $payment->status);
+			$participant->setAttribute(self::ATTR_PARTICIPANT_PAYMENT_ID, $payment->id);
+			$participant->setAttribute(self::ATTR_PARTICIPANT_PAYMENT_STATUS, $payment->status);
 
 			return $payment;
 		}
@@ -920,13 +1096,13 @@ EOF;
 		 * sending out any mails or digests as needed.
 		 *
 		 * When the payment is complete (successful or
-		 * unsuccessful), NULL is returned. If the payment is
+		 * unsuccessful), null is returned. If the payment is
 		 * still open, the url to redirect to is returned.
 		 *
 		 * When create_new is true, a new payment is created if
 		 * the existing one is not paid but no longer opened
 		 * (e.g. expired, failed or cancelled). In this case, a
-		 * NULL return value means the payment was successful.
+		 * null return value means the payment was successful.
 		 *
 		 * Should be called with the XML lock held.
 		 */
@@ -935,17 +1111,16 @@ EOF;
 			require_once('system/Mollie/API/Autoloader.php');
 			$mollie = new Mollie_API_Client;
 			$mollie->setApiKey($this->getConfig('mollie-key'));
-			$changed = false;
 
 			$this->xml->requireLock();
-			$payment = $mollie->payments->get($participant->getAttribute('payment-id'));
+			$payment = $mollie->payments->get($participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_ID));
 
 			// If the status changed, process the change. If
 			// $create_new is true, do not send any "failed"
 			// e-mails, which would only be confusing when
 			// the user is about to start a new payment
 			// attempt.
-			if ($participant->getAttribute('payment-status') != $payment->status)
+			if ($participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_STATUS) != $payment->status)
 				$this->processPaymentChange($participant, $payment, !$create_new);
 
 			// If the payment is not complete and not open,
@@ -957,7 +1132,7 @@ EOF;
 			if ($payment->isOpen())
 				return $payment->getPaymentUrl();
 			else
-				return NULL;
+				return null;
 		}
 
 		/**
@@ -969,27 +1144,30 @@ EOF;
 		 * digest.
 		 */
 		function processPaymentChange($participant, $payment, $mail_failed) {
-			global $hyphaUrl, $hyphaContentLanguage;
-			$participant->setAttribute('payment-status', $payment->status);
+			$participant->setAttribute(self::ATTR_PARTICIPANT_PAYMENT_STATUS, $payment->status);
 			if ($payment->isPaid()) {
-				if (!$participant->getAttribute('payment-timestamp')) {
-					$participant->setAttribute('payment-timestamp', $payment->paidDatetime);
+				if (!$participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_TIMESTAMP)) {
+					$participant->setAttribute(self::ATTR_PARTICIPANT_PAYMENT_TIMESTAMP, $payment->paidDatetime);
 
 					// Send email
-					$contribute_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/contribute/' . $participant->getAttribute('xml:id') . '/' . $participant->getAttribute('key');
-					$append = '<p><a href="'.htmlspecialchars($contribute_url).'">'.__('festival-contribute') . '</a></p>';
-					$this->sendMail($participant->getAttribute('email'), 'mail-signed-up-payed', $append);
+					$contribute_url = $this->constructFullPath($this->pagename . '/' . self::PATH_CONTRIBUTE . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
+					$vars = [
+						'festival-title' => $this->getConfig(self::CONFIG_ID_TITLE),
+						'contributelink' => $contribute_url,
+					];
+					$rcpt = $participant->getAttribute(self::ATTR_PARTICIPANT_EMAIL);
+					$this->sendMail($rcpt, 'festival-payment-succesful', $vars);
 
 					// Add to digest
-					$digest = htmlspecialchars($participant->getAttribute('name') . __('festival-payed-for') . $this->getConfig('festival-title'));
-					$digest .= ' (€' . $participant->getAttribute('payment-amount') . ')';
+					$digest = htmlspecialchars($participant->getAttribute(self::ATTR_PARTICIPANT_NAME) . __('festival-payed-for') . $this->getConfig(self::CONFIG_ID_TITLE));
+					$digest .= ' (€' . $participant->getAttribute(self::ATTR_PARTICIPANT_PAYMENT_AMOUNT) . ')';
 					$digest .= ' (<a href="' . $contribute_url . '">Add contribution</a>)';
 					writeToDigest($digest, 'festival-payment');
 				}
 
 				// Payment complete, no payment url to
 				// redirect to
-				return NULL;
+				return null;
 			}
 
 			$error_statuses = [
@@ -999,23 +1177,26 @@ EOF;
 			];
 			if (in_array($payment->status, $error_statuses)) {
 				if ($mail_failed) {
-					$pay_url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/pay/' . $participant->getAttribute('xml:id') . '/' . $participant->getAttribute('key');
-					$append = '<p><a href="'.htmlspecialchars($pay_url).'">'.__('festival-restart-payment') . '</a></p>';
-					$this->sendMail($participant->getAttribute('email'), 'mail-payment-failed', $append);
+					$pay_url = $this->constructFullPath($this->pagename . '/' . self::PATH_PAY . '/' . $participant->getId() . '/' . $participant->getAttribute(self::ATTR_PARTICIPANT_KEY));
+					$vars = [
+						'festival-title' => $this->getConfig(self::CONFIG_ID_TITLE),
+						'paylink' => $pay_url,
+					];
+					$rcpt = $participant->getAttribute(self::ATTR_PARTICIPANT_EMAIL);
+					$this->sendMail($rcpt, 'festival-payment-failed', $vars);
 				}
-				$digest = htmlspecialchars($participant->getAttribute('name') . __('festival-failed-to-pay-for') . $this->getConfig('festival-title') . ' (' . $payment->status . ')');
+				$digest = htmlspecialchars($participant->getAttribute(self::ATTR_PARTICIPANT_NAME) . __('festival-failed-to-pay-for') . $this->getConfig(self::CONFIG_ID_TITLE) . ' (' . $payment->status . ')');
 				writeToDigest($digest, 'error');
 			}
 		}
 
 		/**
-		 * Retrieve the given mail from the config and send it,
-		 * appending the given bit of HTML.
+		 * Retrieve the given mail from the translations and send it,
+		 * interpolating the given variables.
 		 */
-		function sendMail($to, $id, $append) {
-			$elem = $this->getConfigElement($id);
-			$body = $elem->html() . $append;
-			$subject = $elem->getAttribute('subject');
+		function sendMail($to, $id, $vars) {
+			$subject = __($id . '-subject', $vars);
+			$body = __($id . '-body', $vars);
 
 			return sendMail($to, $subject, $body);
 		}
@@ -1034,23 +1215,52 @@ EOF;
 		 * even if the key is not present. If no id is present
 		 * either, the user object itself will be returned.
 		 */
-		function checkKeyArguments($tags, $allow_user = false) {
-			global $hyphaUser;
-			$id = $this->getArg(1);
+		function checkKeyArguments(HyphaRequest $request, array $tags, $allow_user = false) {
+			$id = $request->getArg(1);
 			if ($id) {
 				$obj = $this->xml->getElementById($id);
 				if ($obj && in_array($obj->tagName, $tags)) {
-					$key = $this->getArg(2);
-					if (!$key && $allow_user && isUser() ||
-					    $key && $obj->getAttribute('key') == $key) {
+					$key = $request->getArg(2);
+					if (!$key && $allow_user && $this->O_O->isUser() ||
+					    $key && $obj->getAttribute(self::ATTR_KEY) == $key) {
 						return $obj;
 					}
 				}
-			} else if ($allow_user && isUser()) {
-				return $hyphaUser;
+			} else if ($allow_user && $this->O_O->isUser()) {
+				return $this->O_O->getUser();
 			}
 			notify('error', __('invalid-or-no-key'));
 			return false;
 		}
 
+		/**
+		 * @todo [LRM]: move so it can be used throughout Hypha
+		 * @param string $label
+		 * @param null|string $path
+		 * @param null|string $command
+		 * @param null|string $argument
+		 *
+		 * @return string
+		 */
+		protected function makeActionButton($label, $path = null, $command = null, $argument = null) {
+			$path = $this->language . '/' . $this->pagename . ($path ? '/' . $path : '');
+			$_action = makeAction($path, ($command ? $command : ''), ($argument ? $argument : ''));
+
+			return makeButton(__($label), $_action);
+		}
+
+		/**
+		 * @todo [LRM]: move so it can be used throughout Hypha
+		 * @param string $path
+		 * @param null|string $language
+		 *
+		 * @return string
+		 */
+		protected function constructFullPath($path, $language = null) {
+			$rootUrl = $this->O_O->getRequest()->getRootUrl();
+			$language = null == $language ? $this->language : $language;
+			$path = '' == $path ? '' : '/' . $path;
+
+			return $rootUrl . $language . $path;
+		}
 	}

--- a/system/datatypes/festival.php
+++ b/system/datatypes/festival.php
@@ -676,7 +676,7 @@ EOF;
 		function buildContribution($contribution) {
 			global $hyphaUrl, $hyphaContentLanguage;
 			$html = '<div class="infoact">';
-			// artist and title
+			// name and title
 			$id = $contribution->getAttribute('xml:id');
 			$url = $hyphaUrl . $hyphaContentLanguage . '/' . $this->pagename . '/lineup#' . $id;
 			$editurl = $hyphaContentLanguage .'/'.$this->pagename.'/contribute/'.$contribution->getAttribute('xml:id');
@@ -803,7 +803,7 @@ EOF;
 						$events = $contribution->getElementsByTagName('event');
 						foreach($events as $event) {
 							if ($event->getAttribute('day') == $day->getId() && $event->getAttribute('location') == $location->getId())
-								$locevents[] = [$this->timetocols($daybegin, $event->getAttribute('begin')), $this->timetocols($daybegin, $event->getAttribute('end')), $contribution->getAttribute('artist'), $contribution->getId(), $contribution->getAttribute('title')];
+								$locevents[] = [$this->timetocols($daybegin, $event->getAttribute('begin')), $this->timetocols($daybegin, $event->getAttribute('end')), $contribution->getAttribute('name'), $contribution->getId(), $contribution->getAttribute('title')];
 						}
 					}
 

--- a/system/datatypes/festival.php
+++ b/system/datatypes/festival.php
@@ -89,11 +89,13 @@
 					return $this->handlePaymentHook();
 				case 'contribute':
 					return $this->showContribute();
-				default:
 				case 'lineup':
+				case '':
 					return $this->showLineup();
 				case 'timetable':
 					return $this->showTimetable();
+				default:
+                                        return '404';
 			}
 		}
 

--- a/system/datatypes/festival.php
+++ b/system/datatypes/festival.php
@@ -30,7 +30,7 @@
 			if (isUser() && !in_array($this->getArg(0), ['edit'])) {
 				$commands = $this->html->find('#pageCommands');
 
-				$action = makeAction($this->language . '/' . $this->pagename . '/edit', '', '');
+				$action = makeAction($this->language . '/' . $this->pagename . '/settings', '', '');
 				$button = makeButton(__('settings'), $action);
 				$commands->append($button);
 
@@ -70,7 +70,7 @@
 				case 'translate':
 					return $this->translate();
 			*/
-				case 'edit':
+				case 'settings':
 					return $this->showSettings();
 				case 'participants':
 					return $this->showParticipants();

--- a/system/datatypes/festival.php
+++ b/system/datatypes/festival.php
@@ -803,7 +803,7 @@ EOF;
 						$events = $contribution->getElementsByTagName('event');
 						foreach($events as $event) {
 							if ($event->getAttribute('day') == $day->getId() && $event->getAttribute('location') == $location->getId())
-								$locevents[] = $this->timetocols($daybegin, $event->getAttribute('begin')).'|'.$this->timetocols($daybegin, $event->getAttribute('end')).'|'.$contribution->getAttribute('artist').'|'.$contribution->getId().'|'.$contribution->getAttribute('title');
+								$locevents[] = [$this->timetocols($daybegin, $event->getAttribute('begin')), $this->timetocols($daybegin, $event->getAttribute('end')), $contribution->getAttribute('artist'), $contribution->getId(), $contribution->getAttribute('title')];
 						}
 					}
 
@@ -813,10 +813,10 @@ EOF;
 						$endOfLastTimeSlot = 0;
 						$p=0;
 						while($p<count($locevents)) {
-							$timeslot = explode('|',$locevents[$p]);
+							$timeslot = $locevents[$p];
 							if ($timeslot[0]>=$endOfLastTimeSlot) {
 								$endOfLastTimeSlot = $timeslot[1];
-								$row[] = implode('|',$timeslot);
+								$row[] = $timeslot;
 								array_splice($locevents, $p, 1);
 							}
 							else $p++;
@@ -838,7 +838,7 @@ EOF;
 						$t = $daybegin;
 						$t = 0;
 						for ($r=0; $r<count($row); $r++) {
-							$timeslot = explode('|', $row[$r]);
+							$timeslot = $row[$r];
 							$id = "a".$d.'_'.$l.'_'.$r;
 							if ($timeslot[0] - $t) $html.= '<td class="'.($line%2 ? 'tableRowOdd' : 'tableRowEven').'" colspan="'.($timeslot[0] - $t).'"></td>';
 							//$html.= '<td id="'.$id.'" class="hover tableAct '.($line%2 ? 'tableRowOddAct' : 'tableRowEvenAct').'" colspan="'.($timeslot[1] - $timeslot[0]).'" onmouseover="showhide(\''.$id.'\',-120,0,\'act\',\''.$timeslot[3].'\');" onmouseout="showhide();">'.$timeslot[2];
@@ -864,8 +864,7 @@ EOF;
 		function timetocols($t1, $t2) {
 			$c1=12*intval(substr($t1,0,2)) + intval(substr($t1,3,2))/5;
 			$c2=12*intval(substr($t2,0,2)) + intval(substr($t2,3,2))/5;
-			$c = $c2 - $c1;
-			return str_repeat("0", 3-strlen($c)).$c;
+			return $c2 - $c1;
 		}
 
 		/**

--- a/system/datatypes/mailinglist.php
+++ b/system/datatypes/mailinglist.php
@@ -14,7 +14,7 @@ use DOMWrap\NodeList;
 
 class mailinglist extends HyphaDatatypePage {
 	/** @var Xml */
-	private $xml;
+	protected $xml;
 
 	const FIELD_NAME_ADDRESSES_CONTAINER = 'addresses';
 	const FIELD_NAME_MAILINGS_CONTAINER = 'mailings';
@@ -82,7 +82,7 @@ class mailinglist extends HyphaDatatypePage {
 	/**
 	 * @return HyphaDomElement|DOMElement
 	 */
-	private function getDoc() {
+	protected function getDoc() {
 		return $this->xml->documentElement;
 	}
 
@@ -133,7 +133,7 @@ class mailinglist extends HyphaDatatypePage {
 	/**
 	 * Checks if the status is new and if so builds the structure and sets the status to draft.
 	 */
-	private function ensureStructure() {
+	protected function ensureStructure() {
 		$dataStructure = [
 			self::FIELD_NAME_DESCRIPTION => [],
 			self::FIELD_NAME_ADDRESSES_CONTAINER => [],
@@ -159,14 +159,14 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return string|null
 	 */
-	private function defaultView(HyphaRequest $request) {
+	protected function defaultView(HyphaRequest $request) {
 		// create form
 		$form = $this->createSubscribeForm();
 
 		return $this->defaultViewRender($request, $form);
 	}
 
-	private function defaultViewRender(HyphaRequest $request, WymHTMLForm $form) {
+	protected function defaultViewRender(HyphaRequest $request, WymHTMLForm $form) {
 		// add edit button for registered users
 		if (isUser()) {
 			/** @var HyphaDomElement $commands */
@@ -212,7 +212,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array
 	 */
-	private function deleteAction(HyphaRequest $request) {
+	protected function deleteAction(HyphaRequest $request) {
 		if (!isAdmin()) {
 			notify('error', __(isUser() ? 'admin-rights-needed-to-perform-action' : 'login-to-perform-action'));
 			return null;
@@ -230,7 +230,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	private function editView(HyphaRequest $request) {
+	protected function editView(HyphaRequest $request) {
 		if (!isUser()) {
 			notify('error', __('login-to-perform-action'));
 
@@ -253,7 +253,7 @@ class mailinglist extends HyphaDatatypePage {
 		return $this->editViewRender($request, $form);
 	}
 
-	private function editViewRender(HyphaRequest $request, HTMLForm $form) {
+	protected function editViewRender(HyphaRequest $request, HTMLForm $form) {
 		// update the form dom so that values and errors can be displayed
 		$form->updateDom();
 
@@ -275,7 +275,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	private function editAction(HyphaRequest $request) {
+	protected function editAction(HyphaRequest $request) {
 		if (!isUser()) {
 			notify('error', __('login-to-perform-action'));
 
@@ -319,7 +319,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return string|null
 	 */
-	private function subscribeAction(HyphaRequest $request) {
+	protected function subscribeAction(HyphaRequest $request) {
 		// create form
 		$form = $this->createSubscribeForm($request->getPostData());
 
@@ -383,7 +383,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param string $email
 	 * @return void
 	 */
-	private function sendConfirmationMail($code, $email) {
+	protected function sendConfirmationMail($code, $email) {
 		$confirmUrl = $this->path(self::PATH_CONFIRM_CODE, ['code' => $code]);
 		$confirmLink = '<a href="' . htmlspecialchars($confirmUrl) . '">' . __('ml-please-confirm-email') . '</a>';
 		$welcomeText = $this->getDoc()->get(self::FIELD_NAME_EMAIL_WELCOME_TEXT)->getHtml();
@@ -392,7 +392,7 @@ class mailinglist extends HyphaDatatypePage {
 		return $this->sendMail($subject, $welcomeText, [$email]);
 	}
 
-	private function confirmEmailAction(HyphaRequest $request) {
+	protected function confirmEmailAction(HyphaRequest $request) {
 		$code = isset($_GET['code']) ? $_GET['code'] : null;
 		if (null == $code) {
 			notify('error', __('missing-arguments'));
@@ -422,7 +422,7 @@ class mailinglist extends HyphaDatatypePage {
 		return ['redirect', $this->path()];
 	}
 
-	private function unsubscribeAction(HyphaRequest $request) {
+	protected function unsubscribeAction(HyphaRequest $request) {
 		$code = isset($_GET['code']) ? $_GET['code'] : null;
 		if (null == $code) {
 			notify('error', __('missing-arguments'));
@@ -449,7 +449,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	private function unsubscribeByAdminAction(HyphaRequest $request) {
+	protected function unsubscribeByAdminAction(HyphaRequest $request) {
 		if (!isAdmin()) {
 			notify('error', __(isUser() ? 'admin-rights-needed-to-perform-action' : 'login-to-perform-action'));
 			return ['redirect', $this->path()];
@@ -478,7 +478,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param string $xpath
 	 * @throws Exception
 	 */
-	private function unsubscribe($xpath) {
+	protected function unsubscribe($xpath) {
 		$this->xml->lockAndReload();
 
 		$address = $this->findAddresses($xpath)->first();
@@ -507,7 +507,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return null|array
 	 */
-	private function remindAction(HyphaRequest $request) {
+	protected function remindAction(HyphaRequest $request) {
 		if (!isAdmin()) {
 			notify('error', __(isUser() ? 'admin-rights-needed-to-perform-action' : 'login-to-perform-action'));
 			return ['redirect', $this->path()];
@@ -556,7 +556,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return null|array
 	 */
-	private function deleteAddressAction(HyphaRequest $request) {
+	protected function deleteAddressAction(HyphaRequest $request) {
 		if (!isAdmin()) {
 			notify('error', __(isUser() ? 'admin-rights-needed-to-perform-action' : 'login-to-perform-action'));
 			return ['redirect', $this->path()];
@@ -599,7 +599,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	private function addressesView(HyphaRequest $request) {
+	protected function addressesView(HyphaRequest $request) {
 		if (!isUser()) {
 			notify('error', __('login-to-perform-action'));
 			return ['redirect', $this->path()];
@@ -654,7 +654,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @return null
 	 * @throws Exception
 	 */
-	private function mailingView(HyphaRequest $request) {
+	protected function mailingView(HyphaRequest $request) {
 		$mailingId = $request->getArg(1);
 
 		// check if given id was correct
@@ -719,7 +719,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null|void
 	 */
-	private function mailingNewView(HyphaRequest $request) {
+	protected function mailingNewView(HyphaRequest $request) {
 		if (!isUser()) {
 			notify('error', __('login-to-perform-action'));
 			return null;
@@ -731,7 +731,7 @@ class mailinglist extends HyphaDatatypePage {
 		return $this->mailingFormViewRender($form, '', self::PATH_MAILS_NEW);
 	}
 
-	private function mailingFormViewRender(WymHTMLForm $form, $cancelPath, $submitPath) {
+	protected function mailingFormViewRender(WymHTMLForm $form, $cancelPath, $submitPath) {
 		// update the form dom so that values and errors can be displayed
 		$form->updateDom();
 
@@ -749,7 +749,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null|void
 	 */
-	private function mailingNewAction(HyphaRequest $request) {
+	protected function mailingNewAction(HyphaRequest $request) {
 		if (!isUser()) {
 			notify('error', __('login-to-perform-action'));
 			return null;
@@ -790,7 +790,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return string|array|null
 	 */
-	private function mailingEditView(HyphaRequest $request) {
+	protected function mailingEditView(HyphaRequest $request) {
 		if (!isUser()) {
 			notify('error', __('login-to-perform-action'));
 
@@ -833,7 +833,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return string|array|null
 	 */
-	private function mailingEditAction(HyphaRequest $request) {
+	protected function mailingEditAction(HyphaRequest $request) {
 		// throw error if edit is requested without client logged in
 		if (!isUser()) {
 			notify('error', __('login-to-edit'));
@@ -887,7 +887,7 @@ class mailinglist extends HyphaDatatypePage {
 	 * @param array $values
 	 * @return WymHTMLForm
 	 */
-	private function createSubscribeForm(array $values = []) {
+	protected function createSubscribeForm(array $values = []) {
 		$html = <<<EOF
 			<div class="section" style="padding:5px; margin-bottom:5px; position:relative;">
 				<label for="[[field-name-email]]">[[email]]</label>: <input type="text" id="[[field-name-email]]" name="[[field-name-email]]" placeholder="[[email]]" />
@@ -908,7 +908,7 @@ EOF;
 	 * @param array $values
 	 * @return WymHTMLForm
 	 */
-	private function createEditForm(array $values = []) {
+	protected function createEditForm(array $values = []) {
 		$html = <<<EOF
 			<div class="section" style="padding:5px; margin-bottom:5px; position:relative;">
 				<strong><label for="[[field-name-page-name]]">[[title]]</label></strong> <input type="text" id="[[field-name-page-name]]" name="[[field-name-page-name]]" />
@@ -949,7 +949,7 @@ EOF;
 	 *
 	 * @return WymHTMLForm
 	 */
-	private function createMailingForm(array $values = []) {
+	protected function createMailingForm(array $values = []) {
 		$html = <<<EOF
 			<div class="section" style="padding:5px; margin-bottom:5px; position:relative;">
 				<label for="[[field-name-subject]]"> [[subject]] </label> <input type="text" id="[[field-name-subject]]" name="[[field-name-subject]]" />
@@ -984,7 +984,7 @@ EOF;
 	 * @throws Exception
 	 * @return null
 	 */
-	private function mailingSendAction(HyphaRequest $request) {
+	protected function mailingSendAction(HyphaRequest $request) {
 		if (!$this->hasSender()) {
 			notify('error', __('ml-no-sender'));
 			return null;
@@ -1049,7 +1049,7 @@ EOF;
 		return 'reload';
 	}
 
-	private function mailingSendTestAction(HyphaRequest $request) {
+	protected function mailingSendTestAction(HyphaRequest $request) {
 		if (!$this->hasSender()) {
 			notify('error', __('ml-no-sender'));
 			return null;
@@ -1087,7 +1087,7 @@ EOF;
 	/**
 	 * @return bool
 	 */
-	private function hasSender() {
+	protected function hasSender() {
 		$senderData = $this->getSenderData();
 
 		return '' != $senderData['name'] && '' != $senderData['email'];
@@ -1096,7 +1096,7 @@ EOF;
 	/**
 	 * @return array
 	 */
-	private function getSenderData() {
+	protected function getSenderData() {
 		$senderData = [
 			'name' => $this->getDoc()->getAttribute('sender-name'),
 			'email' => $this->getDoc()->getAttribute('sender-email'),
@@ -1115,7 +1115,7 @@ EOF;
 	 * @param int $length
 	 * @return string
 	 */
-	private function constructCode($length = 16) {
+	protected function constructCode($length = 16) {
 		try {
 			if (function_exists('random_bytes')) {
 				return bin2hex(random_bytes($length));
@@ -1129,7 +1129,7 @@ EOF;
 		return bin2hex(openssl_random_pseudo_bytes($length));
 	}
 
-	private function savePage($pagename = null, $language = null, $privateFlag = null) {
+	protected function savePage($pagename = null, $language = null, $privateFlag = null) {
 		$updateHyphaXml = false;
 		foreach (['pagename', 'language', 'privateFlag'] as $argument) {
 			if (null === $$argument) {
@@ -1155,7 +1155,7 @@ EOF;
 	 *
 	 * @param NodeList $container
 	 */
-	private function appendMailingsList(NodeList $container) {
+	protected function appendMailingsList(NodeList $container) {
 		/** @var HyphaDomElement $mailingsContainer */
 		$mailingsContainer = $this->getDoc()->get(self::FIELD_NAME_MAILINGS_CONTAINER);
 		if (isUser()) {
@@ -1207,7 +1207,7 @@ EOF;
 	 * @param string $xpath
 	 * @return NodeList
 	 */
-	private function findAddresses($xpath) {
+	protected function findAddresses($xpath) {
 		/** @var HyphaDomElement $addressesContainer */
 		$addressesContainer = $this->getDoc()->get(self::FIELD_NAME_ADDRESSES_CONTAINER);
 
@@ -1223,12 +1223,12 @@ EOF;
 	 * @param array $vars An associative array with variables to substitute.
 	 * @return string
 	 */
-	private function path($path = null, $vars = []) {
+	protected function path($path = null, $vars = []) {
 		$path = $path ? '/' . $this->substituteSpecial($path, $vars) : '';
 		return $this->constructFullPath($this->pagename . $path);
 	}
 
-	private function substituteSpecial($string, $vars) {
+	protected function substituteSpecial($string, $vars) {
 		foreach ($vars as $key => &$val) $val = htmlspecialchars($val);
 		return hypha_substitute($string, $vars);
 	}
@@ -1241,7 +1241,7 @@ EOF;
 	 * @param null|string $argument
 	 * @return string
 	 */
-	private function makeActionButton($label, $path = null, $command = null, $argument = null) {
+	protected function makeActionButton($label, $path = null, $command = null, $argument = null) {
 		$path = $this->language . '/' . $this->pagename . ($path ? '/' . $path : '');
 		$_action = makeAction($path, ($command ? $command : ''), ($argument ? $argument : ''));
 
@@ -1254,7 +1254,7 @@ EOF;
 	 * @param null|string $language
 	 * @return string
 	 */
-	private function constructFullPath($path, $language = null) {
+	protected function constructFullPath($path, $language = null) {
 		global $hyphaUrl;
 		$language = null == $language ? $this->language : $language;
 		$path = '' == $path ? '' : '/' . $path;
@@ -1269,7 +1269,7 @@ EOF;
 	 * @param null|string $senderEmail
 	 * @param null|string $senderName
 	 */
-	private function sendMail($subject, $message, array $receivers, $senderEmail = null, $senderName = null) {
+	protected function sendMail($subject, $message, array $receivers, $senderEmail = null, $senderName = null) {
 		$style = 'body {margin-top:10px; margin-left: 10px; font-size:10pt; font-family: Sans; color:black; background-color:white;}';
 		foreach ($receivers as $receiver) {
 			sendMail($receiver, $subject, $message, $senderEmail, $senderName, $style);

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -15,7 +15,7 @@ use DOMWrap\NodeList;
 // TODO [LRM]: add version control on peer_reviewed_article
 class peer_reviewed_article extends HyphaDatatypePage {
 	/** @var Xml */
-	private $xml;
+	protected $xml;
 
 	const FIELD_NAME_USER = 'user';
 	const FIELD_NAME_CREATED_AT = 'created_at';
@@ -89,7 +89,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	const CMD_DISCUSSION_CLOSED = 'discussion_closed';
 	const CMD_COMMENT = 'comment';
 
-	private $statusMtx = [
+	protected $statusMtx = [
 		self::STATUS_NEWLY_CREATED => [],
 		self::STATUS_DRAFT => [self::STATUS_REVIEW => ['label' => 'art-start-review', 'cmd' => self::CMD_STATUS_CHANGE_REVIEW]],
 		self::STATUS_REVIEW => [self::STATUS_APPROVED => ['label' => 'art-approve']],
@@ -168,7 +168,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	/**
 	 * Checks if the status is new and if so builds the structure and sets the status to draft.
 	 */
-	private function ensureStructure() {
+	protected function ensureStructure() {
 		$status = $this->getStatus();
 
 		if (self::STATUS_NEWLY_CREATED !== $status) {
@@ -202,7 +202,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		};
 		$build($this->xml->documentElement, $dataStructure);
 
-		// force private flag
+		// force protected flag
 		if (!$this->privateFlag) {
 			global $hyphaXml;
 			$hyphaXml->lockAndReload();
@@ -232,7 +232,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return null
 	 */
-	public function defaultView(HyphaRequest $request) {
+	protected function defaultView(HyphaRequest $request) {
 		$status = $this->getStatus();
 
 		// add buttons for registered users
@@ -354,7 +354,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		return null;
 	}
 
-	public function appendAuthorAndTimestamp($container, $article) {
+	protected function appendAuthorAndTimestamp($container, $article) {
 		$doc = $container->document();
 
 		$author = $article->getAttribute(self::FIELD_NAME_AUTHOR);
@@ -392,7 +392,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array
 	 */
-	public function deleteAction(HyphaRequest $request) {
+	protected function deleteAction(HyphaRequest $request) {
 		if (!isAdmin()) {
 			notify('error', __('admin-rights-needed-to-perform-action'));
 			return null;
@@ -410,7 +410,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	public function editView(HyphaRequest $request) {
+	protected function editView(HyphaRequest $request) {
 		if (!isUser()) {
 			notify('error', __('login-to-perform-action'));
 			return ['redirect', $this->constructFullPath($this->pagename)];
@@ -438,7 +438,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param WymHTMLForm $form
 	 * @return null
 	 */
-	private function editViewRender(HyphaRequest $request, WymHTMLForm $form) {
+	protected function editViewRender(HyphaRequest $request, WymHTMLForm $form) {
 		// update the form dom so that error can be displayed, if there are any
 		$form->updateDom();
 
@@ -464,7 +464,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	public function editAction(HyphaRequest $request) {
+	protected function editAction(HyphaRequest $request) {
 		if (!isUser()) {
 			notify('error', __('login-to-perform-action'));
 			return ['redirect', $this->constructFullPath($this->pagename)];
@@ -502,7 +502,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param string $newStatus
 	 * @return array
 	 */
-	public function statusChangeAction(HyphaRequest $request, $newStatus) {
+	protected function statusChangeAction(HyphaRequest $request, $newStatus) {
 		if (!isUser()) {
 			notify('error', __('login-to-perform-action'));
 			return ['redirect', $this->constructFullPath($this->pagename)];
@@ -524,7 +524,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array
 	 */
-	public function approveAction(HyphaRequest $request) {
+	protected function approveAction(HyphaRequest $request) {
 		if (!isUser()) {
 			notify('error', __('login-to-perform-action'));
 			return ['redirect', $this->constructFullPath($this->pagename)];
@@ -561,7 +561,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	public function discussionAction(HyphaRequest $request) {
+	protected function discussionAction(HyphaRequest $request) {
 		$type = $request->getArg(1);
 		if ($type === null) {
 			notify('error', __('missing-arguments'));
@@ -619,7 +619,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param null|HyphaDomElement $discussion
 	 * @return null
 	 */
-	private function discussionRender(HyphaRequest $request, WymHTMLForm $form, $type, HyphaDomElement $discussion = null) {
+	protected function discussionRender(HyphaRequest $request, WymHTMLForm $form, $type, HyphaDomElement $discussion = null) {
 		// update the form dom so that error can be displayed, if there are any
 		$form->updateDom();
 
@@ -634,7 +634,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		return null;
 	}
 
-	private function makeDiscussionActionButton($type, HyphaDomElement $discussion = null) {
+	protected function makeDiscussionActionButton($type, HyphaDomElement $discussion = null) {
 		$new = $discussion === null;
 		$review = self::FIELD_NAME_DISCUSSION_REVIEW_CONTAINER === $type;
 
@@ -657,7 +657,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	public function discussionCommentAction(HyphaRequest $request) {
+	protected function discussionCommentAction(HyphaRequest $request) {
 		$discussionId = $request->getArg(1);
 
 		$this->xml->lockAndReload();
@@ -707,7 +707,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	public function discussionClosedAction(HyphaRequest $request) {
+	protected function discussionClosedAction(HyphaRequest $request) {
 		$this->xml->lockAndReload();
 
 		/** @var HyphaDomElement $discussion */
@@ -757,7 +757,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	public function commentConfirmAction(HyphaRequest $request) {
+	protected function commentConfirmAction(HyphaRequest $request) {
 		$code = isset($_GET['code']) ? $_GET['code'] : null;
 		if (null == $code) {
 			notify('error', __('missing-arguments'));
@@ -818,7 +818,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param HyphaRequest $request
 	 * @return array|null
 	 */
-	private function unsubscribeAction(HyphaRequest $request) {
+	protected function unsubscribeAction(HyphaRequest $request) {
 		$code = isset($_GET['code']) ? $_GET['code'] : null;
 		if (null == $code) {
 			notify('error', __('missing-arguments'));
@@ -860,7 +860,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param string $newStatus
 	 * @return bool
 	 */
-	private function updateToNewStatus($newStatus) {
+	protected function updateToNewStatus($newStatus) {
 		$currentStatus = $this->getStatus();
 		if (!isset($this->statusMtx[$currentStatus]) || !isset($this->statusMtx[$currentStatus][$newStatus])) {
 			notify('error', __('art-unsupported-status-change'));
@@ -876,7 +876,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		}
 		$this->xml->saveAndUnlock();
 
-		// remove private flag
+		// remove protected flag
 		if ($newStatus === self::STATUS_PUBLISHED && $this->privateFlag) {
 			global $hyphaXml;
 			$hyphaXml->lockAndReload();
@@ -899,7 +899,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param string dataFieldSuffix
 	 * @return HyphaDomElement
 	 */
-	private function addDiscussion(HyphaDomElement $discussionContainer, WymHTMLForm $form, $dataFieldSuffix) {
+	protected function addDiscussion(HyphaDomElement $discussionContainer, WymHTMLForm $form, $dataFieldSuffix) {
 		$this->xml->requireLock();
 
 		/** @var HyphaDomElement $discussion */
@@ -931,7 +931,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param string dataFieldSuffix
 	 * @return HyphaDomElement
 	 */
-	private function addDiscussionComment(HyphaDomElement $discussion, WymHTMLForm $form, $dataFieldSuffix) {
+	protected function addDiscussionComment(HyphaDomElement $discussion, WymHTMLForm $form, $dataFieldSuffix) {
 		$this->xml->requireLock();
 
 		/** @var HyphaDomElement $comment */
@@ -1001,7 +1001,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 *
 	 * @return HyphaDomElement
 	 */
-	private function createApprovesDomElement() {
+	protected function createApprovesDomElement() {
 		/** @var HyphaDomElement $approvesDomElement */
 		$approvesDomElement = $this->html->createElement('div');
 		$approvesDomElement->attr('class', 'approves');
@@ -1033,7 +1033,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param string $type
 	 * @return HyphaDomElement
 	 */
-	private function createDiscussionsDomElement($type) {
+	protected function createDiscussionsDomElement($type) {
 		/** @var HyphaDomElement $discussionsDomElement */
 		$discussionsDomElement = $this->html->createElement('div');
 		$review = self::FIELD_NAME_DISCUSSION_REVIEW_CONTAINER === $type;
@@ -1168,7 +1168,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 	 * @param array $values
 	 * @return WymHTMLForm
 	 */
-	private function createEditForm(array $values = []) {
+	protected function createEditForm(array $values = []) {
 		$html = <<<EOF
 			<div class="section" style="padding:5px; margin-bottom:5px; position:relative;">
 				<div class="input-wrapper field_type_text field_name_[[field-name-title]]">
@@ -1233,7 +1233,7 @@ EOF;
 	 * @param null|HyphaDomElement $discussion
 	 * @return WymHTMLForm
 	 */
-	private function createCommentForm($type, array $values = [], HyphaDomElement $discussion = null) {
+	protected function createCommentForm($type, array $values = [], HyphaDomElement $discussion = null) {
 		$new = $discussion === null;
 
 		$review = self::FIELD_NAME_DISCUSSION_REVIEW_CONTAINER === $type;
@@ -1302,7 +1302,7 @@ EOF;
 	 * @param null|HyphaDomElement $discussion
 	 * @return string
 	 */
-	private function constructDiscussionFieldSuffix($type, HyphaDomElement $discussion = null) {
+	protected function constructDiscussionFieldSuffix($type, HyphaDomElement $discussion = null) {
 		return $discussion === null ? '/new_' . $type : '/' . $discussion->getId();
 	}
 
@@ -1312,7 +1312,7 @@ EOF;
 	 * @param int $length
 	 * @return string
 	 */
-	private function constructCode($length = 16) {
+	protected function constructCode($length = 16) {
 		try {
 			if (function_exists('random_bytes')) {
 				return bin2hex(random_bytes($length));
@@ -1328,7 +1328,7 @@ EOF;
 	/**
 	 * Sends "status has changed" mail to all users.
 	 */
-	private function sendStatusChangeMail() {
+	protected function sendStatusChangeMail() {
 		$newStatus = $this->getStatus();
 		if (in_array($newStatus, [self::STATUS_NEWLY_CREATED, self::STATUS_DRAFT])) {
 			return;
@@ -1368,7 +1368,7 @@ EOF;
 	 *
 	 * @param HyphaDomElement $comment
 	 */
-	private function sendCommentConfirmMail(HyphaDomElement $comment) {
+	protected function sendCommentConfirmMail(HyphaDomElement $comment) {
 		$code = $comment->getAttribute(self::FIELD_NAME_DISCUSSION_COMMENT_CONFIRM_CODE);
 		$commentBody = $comment->textContent;
 
@@ -1392,7 +1392,7 @@ EOF;
 	 *
 	 * @param HyphaDomElement $comment
 	 */
-	private function sendNewCommentMail(HyphaDomElement $comment) {
+	protected function sendNewCommentMail(HyphaDomElement $comment) {
 		// send newly created comment to all users
 		$title = $this->getTitle();
 		$linkToPage = $this->constructFullPath($this->pagename);
@@ -1440,7 +1440,7 @@ EOF;
 	 * @param HyphaDomElement $comment
 	 * @return HyphaDomElement[]
 	 */
-	private function getSubscribers(HyphaDomElement $comment) {
+	protected function getSubscribers(HyphaDomElement $comment) {
 		/** @var HyphaDomElement $discussion */
 		$discussion = $comment->parent();
 
@@ -1462,7 +1462,7 @@ EOF;
 	 *
 	 * @param HyphaDomElement $discussion
 	 */
-	private function sendBlockingDiscussionMail(HyphaDomElement $discussion) {
+	protected function sendBlockingDiscussionMail(HyphaDomElement $discussion) {
 		$title = $this->getTitle();
 		$author = $this->O_O->getUser()->getAttribute('fullname');
 		$linkToPage = $this->constructFullPath($this->pagename);
@@ -1484,7 +1484,7 @@ EOF;
 	/**
 	 * Sends "block has been resolved" mail to all users.
 	 */
-	private function sendResolvedBlockingDiscussionMail() {
+	protected function sendResolvedBlockingDiscussionMail() {
 		$title = $this->getTitle();
 		$author = $this->O_O->getUser()->getAttribute('fullname');
 		$linkToPage = $this->constructFullPath($this->pagename);
@@ -1506,7 +1506,7 @@ EOF;
 	 * @param string $subject
 	 * @param string $message
 	 */
-	private function sendMail($receivers, $subject, $message) {
+	protected function sendMail($receivers, $subject, $message) {
 		$style = 'body {margin-top:10px; margin-left: 10px; font-size:10pt; font-family: Sans; color:black; background-color:white;}';
 		sendMail($receivers, hypha_getTitle() . ': '. $subject, $message, hypha_getEmail(), hypha_getTitle(), $style);
 	}
@@ -1542,7 +1542,7 @@ EOF;
 	 *
 	 * @return string
 	 */
-	private function getStatus() {
+	protected function getStatus() {
 		/** @var HyphaDomElement $article */
 		$article = $this->xml->find(self::FIELD_NAME_ARTICLE)->first();
 		if ($article instanceof HyphaDomElement) {
@@ -1562,7 +1562,7 @@ EOF;
 	 *
 	 * @return bool
 	 */
-	private function canBeSetAsApproved() {
+	protected function canBeSetAsApproved() {
 		/** @var HyphaDomElement $discussions */
 		$discussions = $this->xml->find(self::FIELD_NAME_DISCUSSION_CONTAINER);
 		/** @var NodeList $blockingDiscussions */
@@ -1587,7 +1587,7 @@ EOF;
 	 * @param string $userId
 	 * @return bool
 	 */
-	private function hasUserApproved($userId) {
+	protected function hasUserApproved($userId) {
 		/** @var HyphaDomElement $approves */
 		$approves = $this->xml->find(self::FIELD_NAME_APPROVE_CONTAINER);
 		/** @var NodeList $approveCollection */
@@ -1602,7 +1602,7 @@ EOF;
 	 * @param HyphaDomElement $comment
 	 * @return string
 	 */
-	private function getCommentCommenter(HyphaDomElement $comment) {
+	protected function getCommentCommenter(HyphaDomElement $comment) {
 		$userId = $comment->getAttribute(self::FIELD_NAME_USER);
 		if ($userId) {
 			$user = hypha_getUserById($userId);
@@ -1619,7 +1619,7 @@ EOF;
 	 * @param null|string|array $argument
 	 * @return string
 	 */
-	private function makeActionButton($label, $path = null, $command = null, $argument = null) {
+	protected function makeActionButton($label, $path = null, $command = null, $argument = null) {
 		if (is_array($argument)) {
 			$argument = json_encode($argument);
 		}
@@ -1635,7 +1635,7 @@ EOF;
 	 * @param null|string $language
 	 * @return string
 	 */
-	private function constructFullPath($path, $language = null) {
+	protected function constructFullPath($path, $language = null) {
 		global $hyphaUrl;
 		$language = null == $language ? $this->language : $language;
 		$path = '' == $path ? '' : '/' . $path;

--- a/system/datatypes/tagindex.php
+++ b/system/datatypes/tagindex.php
@@ -12,7 +12,7 @@
 			return $this->tagIndexView($request);
 		}
 
-		public function tagIndexView(HyphaRequest $request) {
+		protected function tagIndexView(HyphaRequest $request) {
 			$lang = $request->getArg(0);
 			// TODO: This urldecode should really be done by
 			// HyphaRequest (#274)
@@ -44,7 +44,7 @@
 			$main->append($pagesList);
 		}
 
-		private function sortPages($pages) {
+		protected function sortPages($pages) {
 			// TODO: This should cache sort dates
 			$compare = function($a, $b) {
 				$aDate = $a->getSortDateTime();
@@ -56,7 +56,7 @@
 			return $pages;
 		}
 
-		private function getPages(HyphaTag $tag, $includePrivate = false) {
+		protected function getPages(HyphaTag $tag, $includePrivate = false) {
 			$pageTypes = []; // All pagetypes
 			$pageNodes = HyphaTags::findPagesWithTags($tag, $pageTypes, $includePrivate);
 			$pages = [];
@@ -66,7 +66,7 @@
 			return $pages;
 		}
 
-		private function renderPages($pages) {
+		protected function renderPages($pages) {
 			/** @var HyphaDomElement $ul */
 			$ul = $this->html->createElement('ul');
 			$ul->addClass('tagindex');
@@ -77,7 +77,7 @@
 			return $ul;
 		}
 
-		private function renderPage(HyphaDatatypePage $page) {
+		protected function renderPage(HyphaDatatypePage $page) {
 			$li = $this->html->createElement('li');
 			$li->addClass('tagindex-item');
 			$li->addClass('type_' . get_class($page));

--- a/system/datatypes/text.php
+++ b/system/datatypes/text.php
@@ -8,7 +8,7 @@
 */
 	class textpage extends HyphaDatatypePage {
 		/** @var Xml */
-		public $xml;
+		protected $xml;
 
 		const FIELD_NAME_PAGE_NAME = 'textPagename';
 		const FIELD_NAME_LANGUAGE = 'textLanguage';
@@ -53,7 +53,7 @@
 			return new DateTime("@" . $timestamp);
 		}
 
-		private function defaultView(HyphaRequest $request) {
+		protected function defaultView(HyphaRequest $request) {
 			// setup language and tag list for the selected page
 			$this->html->writeToElement('langList', hypha_indexLanguages($this->pageListNode, $this->language));
 
@@ -90,7 +90,7 @@
 		 *
 		 * @return WymHTMLForm
 		 */
-		private function createEditForm(array $values = []) {
+		protected function createEditForm(array $values = []) {
 			$html = <<<EOF
 				<div class="section">
 					<label for="[[field-name-title]]">[[title]]</label>
@@ -113,7 +113,7 @@ EOF;
 			return new WymHTMLForm($html, $values);
 		}
 
-		private function editView(HyphaRequest $request) {
+		protected function editView(HyphaRequest $request) {
 			if (!isUser()) {
 				notify('error', __('login-to-perform-action'));
 
@@ -131,7 +131,7 @@ EOF;
 			return $this->editViewRender($request, $form);
 		}
 
-		private function editViewRender(HyphaRequest $request, HTMLForm $form) {
+		protected function editViewRender(HyphaRequest $request, HTMLForm $form) {
 			// update the form dom so that error can be displayed, if there are any
 			$form->updateDom();
 
@@ -144,7 +144,7 @@ EOF;
 			return null;
 		}
 
-		private function editAction(HyphaRequest $request) {
+		protected function editAction(HyphaRequest $request) {
 			if (!isUser()) {
 				notify('error', __('login-to-preform-action'));
 
@@ -177,7 +177,7 @@ EOF;
 			return ['redirect', $this->constructFullPath($pagename)];
 		}
 
-		private function translateView(HyphaRequest $request) {
+		protected function translateView(HyphaRequest $request) {
 			if (!isUser()) {
 				notify('error', __('login-to-preform-action'));
 
@@ -195,7 +195,7 @@ EOF;
 			return $this->translateViewRender($request, $form);
 		}
 
-		private function translateViewRender(HyphaRequest $request, HTMLForm $form) {
+		protected function translateViewRender(HyphaRequest $request, HTMLForm $form) {
 			$form->updateDom();
 
 			$this->html->find('#main')->append($form);
@@ -208,7 +208,7 @@ EOF;
 			return null;
 		}
 
-		private function translateAction(HyphaRequest $request) {
+		protected function translateAction(HyphaRequest $request) {
 			if (!isUser()) {
 				notify('error', __('login-to-preform-action'));
 
@@ -242,7 +242,7 @@ EOF;
 			return ['redirect', $this->constructFullPath($pagename, $language)];
 		}
 
-		private function revertAction(HyphaRequest $request) {
+		protected function revertAction(HyphaRequest $request) {
 			if (!isUser()) {
 				notify('error', __('login-to-preform-action'));
 
@@ -261,7 +261,7 @@ EOF;
 			return ['redirect', $this->constructFullPath($this->pagename)];
 		}
 
-		private function deleteAction(HyphaRequest $request) {
+		protected function deleteAction(HyphaRequest $request) {
 			if (!isAdmin()) return notify('error', __('login-as-admin-to-delete'));
 
 			$this->deletePage();
@@ -274,7 +274,7 @@ EOF;
 		 * @param array $values
 		 * @return WymHTMLForm
 		 */
-		private function createTranslationForm(array $values = []) {
+		protected function createTranslationForm(array $values = []) {
 			$selectedLanguage = isset($values[self::FIELD_NAME_LANGUAGE]) ? $values[self::FIELD_NAME_LANGUAGE] : null;
 			$optionListLanguage = Language::getLanguageOptionList($selectedLanguage, $this->language);
 			$html = <<<EOF
@@ -303,7 +303,7 @@ EOF;
 			return new WymHTMLForm($html, $values);
 		}
 
-		private function savePage($content, $pagename = null, $language = null, $privateFlag = null) {
+		protected function savePage($content, $pagename = null, $language = null, $privateFlag = null) {
 			$updateHyphaXml = false;
 			foreach (['pagename', 'language', 'privateFlag'] as $argument) {
 				if (null === $$argument) {

--- a/system/languages/en.php
+++ b/system/languages/en.php
@@ -234,6 +234,20 @@
 		// festival
 		"datatype.name.festivalpage" => "festival page",
 
+		// festival - form fields
+		"festival-field-festival-title" => "Festival title",
+		"festival-field-name" => "Name",
+		"festival-field-email" => "Email address",
+		"festival-field-phone" => "Phone number",
+		"festival-field-amount" => "Registration Fee (€)",
+		"festival-field-contribution-name" => "Organiser / presenter name",
+		"festival-field-contribution-description" => "Short description",
+		"festival-field-contribution-title" => "Title",
+		"festival-field-contribution-image" => "Image",
+		"festival-field-contribution-website" => "Link to website",
+		"festival-field-contribution-category" => "Category",
+		"festival-field-contribution-notes" => "Notes for the organizers",
+
 		// festival - digest
 		"festival-edited-contribution" => "[[name]] edited contribution: [[contribution]]",
 		"festival-added-contribution" => "[[name]] added contribution: [[contribution]]",
@@ -259,6 +273,19 @@
 		"festival-invalid-or-no-key" => "Invalid or no key given",
 		"festival-email-confirmed-successfully" => "Email address confirmed successfully.",
 		"festival-email-already-confirmed" => "Email address was already confirmed.",
+		"festival-settings-saved" => "Settings saved succesfully.",
+
+		// Festival - confirmation e-mails
+		"festival-payment-failed-subject" => '[[festival-title]]: Payment failed, registration incomplete',
+		"festival-payment-failed-body" => '<p>There was a problem with processing your payment (the payment expired, was cancelled or failed). Until your complete the payment, your registration will remain incomplete.</p><p>To restart the payment process, click <a href="[[paylink]]">this link</a>.</p>',
+		"festival-confirm-registration-subject" => '[[festival-title]]: Confirmation needed to complete registration',
+		"festival-confirm-registration-body" => '<p>Your registration was received succesfully. To confirm your e-mail address and complete the registration, click <a href="[[confirmlink]]">this link</a>.</p>',
+		"festival-payment-succesful-subject" => '[[festival-title]]: Payment received, registration complete',
+		"festival-payment-succesful-body" => '<p>Your payment for [[festival-title]] was succesfully processed, so your registration is now complete. If you want to contribute to the event, you can register your contribution using <a href="[[contributelink]]">this link</a>. You can register multiple contributions by filling in the form multiple times.</p>',
+		"festival-registration-confirmed-subject" => '[[festival-title]]: Email confirmed, registration complete',
+		"festival-registration-confirmed-body" => '<p>Your registration for [[festival-title]] was succesfully processed and is now complete. If you want to contribute to the event, you can register your contribution using <a href="[[contributelink]]">this link</a>. You can register multiple contributions by filling in the form multiple times.</p>',
+		"festival-contribution-added-subject" => '[[festival-title]]: Added contribution "[[title]]"',
+		"festival-contribution-added-body" => '<p>Your contribution "[[title]]" has been added and is now shown on the lineup.</p><p>To edit your contribution, use <a href="[[editlink]]">this link</a>.</p>',
 
 		// festival - buttons & links
 		"festival-modify" => "modify",

--- a/system/languages/en.php
+++ b/system/languages/en.php
@@ -235,8 +235,9 @@
 		"datatype.name.festivalpage" => "festival page",
 
 		// festival - digest
-		"festival-edited-contribution" => " edited contribution: ",
-		"festival-added-contribution" => " added contribution: ",
+		"festival-edited-contribution" => "[[name]] edited contribution: [[contribution]]",
+		"festival-added-contribution" => "[[name]] added contribution: [[contribution]]",
+		"festival-digest-edit-contribution" => "Edit contribution",
 		"festival-signed-up-for" => " signed up for ",
 		"festival-failed-to-pay-for" => " failed to pay for ",
 		"festival-payed-for" => " paid for ",

--- a/system/languages/nl.php
+++ b/system/languages/nl.php
@@ -248,7 +248,7 @@
 		"festival-contribution-added" => "Je bijdrage is toegevoegd aan de lineup.",
 		"festival-contribution-modified" => "Je bijdrage is aangepast.",
 		"festival-complete-by-paying" => "Voltooi je registratie door te betalen m.b.v. onderstaande knop.",
-		"festival-signup-for" => "Signup for ",
+		"festival-signup-for" => "Inschrijven voor ",
 		"festival-pay-for" => "Betaal voor ",
 		"festival-lineup-for" => "Lineup voor ",
 		"festival-timetable-for" => "Blokkenschema voor ",

--- a/system/languages/nl.php
+++ b/system/languages/nl.php
@@ -235,8 +235,9 @@
 		"datatype.name.festivalpage" => "festival pagina",
 
 		// festival - digest
-		"festival-edited-contribution" => " heeft festivalbijdrage aangepast: ",
-		"festival-added-contribution" => " heeft een festivalbijdrage toegevoegd: ",
+		"festival-edited-contribution" => "[[name]] heeft festivalbijdrage aangepast: [[contribution]]",
+		"festival-added-contribution" => "[[name]] heeft een festivalbijdrage toegevoegd: [[contribution]]",
+		"festival-digest-edit-contribution" => "Bijdrage wijzigen",
 		"festival-signed-up-for" => " heeft zich ingeschreven voor ",
 		"festival-failed-to-pay-for" => " kon niet betalen voor ",
 		"festival-payed-for" => " heeft betaald voor ",

--- a/system/languages/nl.php
+++ b/system/languages/nl.php
@@ -234,6 +234,20 @@
 		// festival
 		"datatype.name.festivalpage" => "festival pagina",
 
+		// festival - form fields
+		"festival-field-festival-title" => "Festivaltitel",
+		"festival-field-name" => "Naam",
+		"festival-field-email" => "Email-adres",
+		"festival-field-phone" => "Telefoonnummer",
+		"festival-field-amount" => "Inschrijfgeld (€)",
+		"festival-field-contribution-name" => "Naam van organisator / presentator",
+		"festival-field-contribution-description" => "Korte omschrijving",
+		"festival-field-contribution-title" => "Titel",
+		"festival-field-contribution-image" => "Afbeelding",
+		"festival-field-contribution-website" => "Link naar website",
+		"festival-field-contribution-category" => "Categorie",
+		"festival-field-contribution-notes" => "Opmerkingen voor de organisatie",
+
 		// festival - digest
 		"festival-edited-contribution" => "[[name]] heeft festivalbijdrage aangepast: [[contribution]]",
 		"festival-added-contribution" => "[[name]] heeft een festivalbijdrage toegevoegd: [[contribution]]",
@@ -254,6 +268,19 @@
 		"festival-timetable-for" => "Blokkenschema voor ",
 		"festival-contribute-to" => "Draag bij aan ",
 		"festival-invalid-or-no-key" => "Geen of een ongeldige pagina-id",
+		"festival-settings-saved" => "Instellingen succesvol opgeslagen.",
+
+		// Festival - confirmation e-mails
+		"festival-payment-failed-subject" => '[[festival-title]]: Betaling mislukt, inschrijving niet compleet',
+		"festival-payment-failed-body" => '<p>Er was een probleem bij het verwerken van je betaling (de betaling is verlopen, geannuleerd of mislukt). Totdat je de betaling alsnog voldoet, blijft je inschrijving incompleet.</p><p>Om het betalingsproces op nieuw te doorlopen, klik op <a href="[[paylink]]">deze link</a>.</p>',
+		"festival-confirm-registration-subject" => '[[festival-title]]: Bevestiging nodig voor inschrijving',
+		"festival-confirm-registration-body" => '<p>Je inschrijving was succesvol ontvangen. Om je e-mailadres te bevestigen en de inschrijving compleet te maken, klik op <a href="[[confirmlink]]">deze link</a>.</p>',
+		"festival-payment-succesful-subject" => '[[festival-title]]: Betaling ontvangen, inschrijving compleet',
+		"festival-payment-succesful-body" => '<p>Je betaling voor [[festival-title]] is succesvol verwerkt, dus je inschrijving is nu compleet. Als je wil bijdragen aan het evenement, kun je je bijdrage opgeven met <a href="[[contributelink]]">deze link</a>. Je kunt meerdere bijdragen toevoegen door het formulier meerdere keren in te vullen.</p>',
+		"festival-registration-confirmed-subject" => '[[festival-title]]: E-mailadres bevestigd, inschrijving compleet',
+		"festival-registration-confirmed-body" => '<p>Je inschrijving voor [[festival-title]] was succesvol verwerkt en is nu compleet. Als je wil bijdragen aan het evenement, kun je je bijdrage opgeven met <a href="[[contributelink]]">deze link</a>. Je kunt meerdere bijdragen toevoegen door het formulier meerdere keren in te vullen.</p>',
+		"festival-contribution-added-subject" => '[[festival-title]]: Bijdrage "[[title]]" toegevoegd',
+		"festival-contribution-added-body" => '<p>Je bijdrage "[[title]]" is toegevoegd en wordt nu in de lineup weergegeven.</p><p>Om je bijdrage te wijzigen, gebruik <a href="[[editlink]]">deze link</a>.</p>',
 
 		// festival - buttons & links
 		"festival-modify" => "wijzigen",


### PR DESCRIPTION
This improves the code style of the festival, as we previously did for other datatypes.

This PR starts with a few small refactorings that were easy to separate, and ends with one quite huge commit that applies a lot of changes to the festival module. These could maybe have been separated, but given the size of this refactor, this does not warrant the enormous amount of extra time that would have needed.

There are still some things that are imperfect (e.g. translation strings that get variables appended rather than interpolated), but these can better be fixed later than further enlarging this PR.