### PR TITLE
Remove php flags from htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,3 @@
-php_flag short_open_tag on
 php_flag display_errors on
 RewriteEngine On
 

--- a/.htaccess
+++ b/.htaccess
@@ -1,4 +1,3 @@
-php_flag display_errors on
 RewriteEngine On
 
 # Pass system and data urls through index.php, so it can do access control


### PR DESCRIPTION
These `php_flag` directives are not supported in all Apache configurations, and are not really needed either (see #327).