### PR TITLE
Do not set cookies to https only

### DIFF
--- a/system/core/HyphaSession.php
+++ b/system/core/HyphaSession.php
@@ -29,7 +29,6 @@
 			// accessible to scripts).
 			session_name('hyphaSession');
 			ini_set('session.cookie_path', $request->getRootUrlPath());
-			ini_set('session.cookie_secure', $request->isSecure());
 			ini_set('session.cookie_httponly', true);
 			// This enables browser protections against CSRF
 			// attacks by omitting this cookie from all

--- a/system/core/RequestContext.php
+++ b/system/core/RequestContext.php
@@ -183,7 +183,7 @@
 			          /* expire */ 0,
 			          /* path */ $this->getRequest()->getRootUrlPath(),
 				  /* domain */ "",
-				  /* secure */ $this->getRequest()->isSecure(),
+				  /* secure */ false,
 				  /* http_only */ true);
 		}
 


### PR DESCRIPTION
This was only done for HTTPS-requests, but it turns out this breaks
mixed HTTP/HTTPS configurations, because browser do not store a separate
cookie for HTTP and HTTPS. So when you access the HTTPS version of a
site, the cookie is set as secure (https only) and subsequent HTTP
request will simply not get the cookie at all and cannot change the
cookie into non-secure either.

So this protection can only be enabled again when we know a site is
HTTPS-only, i.e. when #247 is implemented.