### PR TITLE
Render links in article comments

### DIFF
--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -128,7 +128,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		self::STATUS_RETRACTED => [/*self::STATUS_DRAFT => 'to_draft'*/], // "to draft" is not supported yet
 	];
 
-	// Source: /https://urlregex.com
+	// Source: https://urlregex.com
 	const URL_REGEX='/(?:(?:https?|ft|):\/\/)?(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?/iu';
 
 	public static function getDatatypeName() {
@@ -1452,7 +1452,14 @@ EOF;
 		$commentHtml = htmlspecialchars($comment->getText());
 		$commentHtml = preg_replace_callback(self::URL_REGEX, function($matches) {
 			$url = $matches[0];
-			return '<a href="'.$url.'" target="_blank">' . $url . '</a>';
+			if( substr($url,-1) === '.'){
+				$url=substr($url,0,-1);
+				$suffix = '.';
+			}else{
+				$suffix = '';
+			}
+			//return 'A<a href="' . $url . '" target="_blank">' . $url . '</a>' . $suffix. ''; // curiously this does show the suffix
+			return '<a href="' . $url . '" target="_blank">' . $url . '</a>' . $suffix. ''; // this does not show the suffix
 		}, $commentHtml);
 		$commentHtml = nl2br($commentHtml);
 		$commentHtml .= ' <p>' . __('art-by') . ' <strong>' . htmlspecialchars($committerName) . '</strong> ' . __('art-at') . ' ' . htmlspecialchars($createdAt);

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -128,6 +128,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		self::STATUS_RETRACTED => [/*self::STATUS_DRAFT => 'to_draft'*/], // "to draft" is not supported yet
 	];
 
+	// Source: /https://urlregex.com
 	const URL_REGEX='/(?:(?:https?|ft|):\/\/)?(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?/iu';
 
 	public static function getDatatypeName() {
@@ -1448,11 +1449,12 @@ EOF;
 	protected function createCommentDomElement(HyphaDomElement $comment, $review = false, $firstAndBlocking = false, $resolved = false) {
 		$createdAt = date('j-m-y, H:i', ltrim($comment->getAttribute(self::FIELD_NAME_CREATED_AT), 't'));
 		$committerName = $this->getCommentCommenter($comment);
-		$commentHtml = nl2br(htmlspecialchars($comment->getText()));
+		$commentHtml = htmlspecialchars($comment->getText());
 		$commentHtml = preg_replace_callback(self::URL_REGEX, function($matches) {
 			$url = $matches[0];
 			return '<a href="'.$url.'" target="_blank">' . $url . '</a>';
 		}, $commentHtml);
+		$commentHtml = nl2br($commentHtml);
 		$commentHtml .= ' <p>' . __('art-by') . ' <strong>' . htmlspecialchars($committerName) . '</strong> ' . __('art-at') . ' ' . htmlspecialchars($createdAt);
 		if (!$review && isUser()) {
 			$committerEmail = $comment->getAttribute(self::FIELD_NAME_DISCUSSION_COMMENTER_EMAIL);

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -128,6 +128,8 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		self::STATUS_RETRACTED => [/*self::STATUS_DRAFT => 'to_draft'*/], // "to draft" is not supported yet
 	];
 
+	const URL_REGEX='/(?:(?:https?|ft|):\/\/)?(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?/iu';
+
 	public static function getDatatypeName() {
 		return __('datatype.name.peer_reviewed_article');
 	}
@@ -1447,7 +1449,11 @@ EOF;
 		$createdAt = date('j-m-y, H:i', ltrim($comment->getAttribute(self::FIELD_NAME_CREATED_AT), 't'));
 		$committerName = $this->getCommentCommenter($comment);
 		$commentHtml = nl2br(htmlspecialchars($comment->getText()));
-		$commentHtml .= '<p>' . __('art-by') . ' <strong>' . htmlspecialchars($committerName) . '</strong> ' . __('art-at') . ' ' . htmlspecialchars($createdAt);
+		$commentHtml = preg_replace_callback(self::URL_REGEX, function($matches) {
+			$url = $matches[0];
+			return '<a href="'.$url.'" target="_blank">' . $url . '</a>';
+		}, $commentHtml);
+		$commentHtml .= ' <p>' . __('art-by') . ' <strong>' . htmlspecialchars($committerName) . '</strong> ' . __('art-at') . ' ' . htmlspecialchars($createdAt);
 		if (!$review && isUser()) {
 			$committerEmail = $comment->getAttribute(self::FIELD_NAME_DISCUSSION_COMMENTER_EMAIL);
 			$commentHtml .= ' <span> | ' . __('art-email') . ': <a href="mailto:' . htmlspecialchars($committerEmail) . '">' . htmlspecialchars($committerEmail) . '</a></span>';

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -1450,16 +1450,16 @@ EOF;
 		$createdAt = date('j-m-y, H:i', ltrim($comment->getAttribute(self::FIELD_NAME_CREATED_AT), 't'));
 		$committerName = $this->getCommentCommenter($comment);
 		$commentHtml = htmlspecialchars($comment->getText());
-		$commentHtml = preg_replace_callback(self::URL_REGEX, function($matches) {
+		$commentHtml = preg_replace_callback(self::URL_REGEX, function($matches) { // replace urls with links
 			$url = $matches[0];
-			if( substr($url,-1) === '.'){
+			if( substr($url,-1) === '.'){ // ensure that period does not end up in the link
 				$url=substr($url,0,-1);
 				$suffix = '.';
 			}else{
 				$suffix = '';
 			}
-			//return 'A<a href="' . $url . '" target="_blank">' . $url . '</a>' . $suffix. ''; // curiously this does show the suffix
-			return '<a href="' . $url . '" target="_blank">' . $url . '</a>' . $suffix. ''; // this does not show the suffix
+			// encapsulated in a span to prevent trimming by html->create
+			return '<span><a href="' . $url . '" target="_blank">' . $url . '</a>' . $suffix.'</span>';
 		}, $commentHtml);
 		$commentHtml = nl2br($commentHtml);
 		$commentHtml .= ' <p>' . __('art-by') . ' <strong>' . htmlspecialchars($committerName) . '</strong> ' . __('art-at') . ' ' . htmlspecialchars($createdAt);


### PR DESCRIPTION
All links in comments will be formatted:

`www.abc.org` -> `<a href="www.abc.org" target="_blank">www.abc.org</a>`