### PR TITLE
Improve comment links

### DIFF
--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -1452,8 +1452,7 @@ EOF;
 		$commentHtml = htmlspecialchars($comment->getText());
 		$tryToParseLinks = preg_replace_callback(self::URL_REGEX, function($matches) { // replace urls with links
 			$url = $matches[0];
-			// encapsulated in a span to prevent trimming by html->create
-			return '<span><a href="' . $url . '" target="_blank">' . $url . '</a></span>';
+			return '<a href="' . $url . '" target="_blank">' . $url . '</a>';
 		}, $commentHtml);
 
 		if(!is_null($tryToParseLinks)) $commentHtml = $tryToParseLinks; // In case regex fails

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -1450,7 +1450,7 @@ EOF;
 		$createdAt = date('j-m-y, H:i', ltrim($comment->getAttribute(self::FIELD_NAME_CREATED_AT), 't'));
 		$committerName = $this->getCommentCommenter($comment);
 		$commentHtml = htmlspecialchars($comment->getText());
-		$commentHtml = preg_replace_callback(self::URL_REGEX, function($matches) { // replace urls with links
+		$tryToParseLinks = preg_replace_callback(self::URL_REGEX, function($matches) { // replace urls with links
 			$url = $matches[0];
 			if( substr($url,-1) === '.'){ // ensure that period does not end up in the link
 				$url=substr($url,0,-1);
@@ -1461,6 +1461,9 @@ EOF;
 			// encapsulated in a span to prevent trimming by html->create
 			return '<span><a href="' . $url . '" target="_blank">' . $url . '</a>' . $suffix.'</span>';
 		}, $commentHtml);
+
+		if(!is_null($tryToParseLinks)) $commentHtml = $tryToParseLinks; // In case regex fails
+
 		$commentHtml = nl2br($commentHtml);
 		$commentHtml .= ' <p>' . __('art-by') . ' <strong>' . htmlspecialchars($committerName) . '</strong> ' . __('art-at') . ' ' . htmlspecialchars($createdAt);
 		if (!$review && isUser()) {

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -128,8 +128,8 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		self::STATUS_RETRACTED => [/*self::STATUS_DRAFT => 'to_draft'*/], // "to draft" is not supported yet
 	];
 
-	const URL_REGEX='/(https?:\/\/|www.)[\w\/-]+\.[\w\/-?=%.&#_]*/iu';
-	// [protocol://|www.] [word] . [suffix /path ?query&parameter=value#bookmark]
+	const URL_REGEX='/(https?:\/\/|www.)[\w\/-]+\.[\w\/-?=%.&#_]*[\w\/-?=%&#_]/iu';
+	// [protocol://|www.] [word] . [suffix /path ?query&parameter=value#bookmark] [last char must not be a dot]
 
 	public static function getDatatypeName() {
 		return __('datatype.name.peer_reviewed_article');
@@ -1452,14 +1452,8 @@ EOF;
 		$commentHtml = htmlspecialchars($comment->getText());
 		$tryToParseLinks = preg_replace_callback(self::URL_REGEX, function($matches) { // replace urls with links
 			$url = $matches[0];
-			if( substr($url,-1) === '.'){ // ensure that period does not end up in the link
-				$url=substr($url,0,-1);
-				$suffix = '.';
-			}else{
-				$suffix = '';
-			}
 			// encapsulated in a span to prevent trimming by html->create
-			return '<span><a href="' . $url . '" target="_blank">' . $url . '</a>' . $suffix.'</span>';
+			return '<span><a href="' . $url . '" target="_blank">' . $url . '</a></span>';
 		}, $commentHtml);
 
 		if(!is_null($tryToParseLinks)) $commentHtml = $tryToParseLinks; // In case regex fails

--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -128,8 +128,8 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		self::STATUS_RETRACTED => [/*self::STATUS_DRAFT => 'to_draft'*/], // "to draft" is not supported yet
 	];
 
-	// Source: https://urlregex.com
-	const URL_REGEX='/(?:(?:https?|ft|):\/\/)?(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?/iu';
+	const URL_REGEX='/(https?:\/\/|www.)[\w\/-]+\.[\w\/-?=%.&#_]*/iu';
+	// [protocol://|www.] [word] . [suffix /path ?query&parameter=value#bookmark]
 
 	public static function getDatatypeName() {
 		return __('datatype.name.peer_reviewed_article');

--- a/system/php-dom-wrapper/Traits/ManipulationTrait.php
+++ b/system/php-dom-wrapper/Traits/ManipulationTrait.php
@@ -107,7 +107,7 @@ trait ManipulationTrait
     protected function nodesFromHtml($html) {
         $class = get_class($this->document());
         $doc = new $class();
-        $nodes = $doc->html($html)->find('body > *');
+        $nodes = $doc->html($html)->findXPath('//body/node()');
 
         return $nodes;
     }


### PR DESCRIPTION
This adresses some problems with the comment links feature merged in #356, as discussed in https://github.com/PlanBCode/hypha/pull/356#issuecomment-743437016 onwards.

This PR contains the commits previously pushed by @RoukePouw, but I:
 - Split his first commit into two
 - Added a fix for php-dom-wrapper's `create` method eating up text not wrapped in a span or so. I've suggested this same fix upstream, and I'd like to hear their response before merging this here (ideally, we could just backport a fix with an upstream commit reference as we've done before). See https://github.com/scotteh/php-dom-wrapper/issues/15#issuecomment-750145412
 - Limited the regex to require either http://, https:// or a `www` prefix, to prevent matching words with a dot halfway.
 - Added `_` to the allowed characters in urls
 - Removed the non-greedy `*?` matching and removed the `+` from the trailing non-dot, since that would prevent a domain with three components (e.g. https://www.dewar.nl) from being matched.
 - Removed one reference to the now-removed `$suffix` variable.
 - Rebased on top of master.

@RoukePouw, how does this look? If this looks ok to you and the php-dom-wrapper maintainer applies this fix upstream, I think this addresses everything?