### PR TITLE
Use different cookie names on HTTPS

### DIFF
--- a/system/core/HyphaSession.php
+++ b/system/core/HyphaSession.php
@@ -27,9 +27,19 @@
 			// (not sent over HTTP) if appropriate, and
 			// *only* sent on http(s) requests (not
 			// accessible to scripts).
-			session_name('hyphaSession');
+			// Use a diferent name for the Https cookie, so
+			// a secure HTTPS session can coexist with an
+			// insecure HTTP session (Without this, the HTTP
+			// session simply breaks because the cookie is
+			// marked as secure and thus off-limits for HTTP).
+			$secure = $request->isSecure();
+			if ($secure)
+				$name = 'hyphaSessionSecure';
+			else
+				$name = 'hyphaSessionInsecure';
+			session_name($name);
 			ini_set('session.cookie_path', $request->getRootUrlPath());
-			ini_set('session.cookie_secure', $request->isSecure());
+			ini_set('session.cookie_secure', $secure);
 			ini_set('session.cookie_httponly', true);
 			// This enables browser protections against CSRF
 			// attacks by omitting this cookie from all

--- a/system/core/RequestContext.php
+++ b/system/core/RequestContext.php
@@ -40,7 +40,8 @@
 				$this->hyphaUser = hypha_getUserById($userid);
 			else
 				$this->hyphaUser = null;
-			$this->csrfToken = isset($_COOKIE['hyphaCsrfToken']) ? $_COOKIE['hyphaCsrfToken'] : null;
+			$name = $this->getCsrfTokenCookieName();
+			$this->csrfToken = isset($_COOKIE[$name]) ? $_COOKIE[$name] : null;
 
 			$theme = $this->getThemeName();
 			$this->data = new StdClass();
@@ -145,6 +146,18 @@
 			return $this->dictionary;
 		}
 
+		protected function getCsrfTokenCookieName() {
+			// Use a diferent name for the Https cookie, so
+			// a secure HTTPS session can coexist with an
+			// insecure HTTP session (Without this, the HTTP
+			// session simply breaks because the cookie is
+			// marked as secure and thus off-limits for HTTP).
+			if ($this->getRequest()->isSecure())
+				return 'hyphaCsrfTokenSecure';
+			else
+				return 'hyphaCsrfTokenInsecure';
+		}
+
 		/*
 			Function: getOrGenerateCsrfToken
 
@@ -179,11 +192,12 @@
 			// Cookies are well-protected by the browser, so
 			// it is not possible for other sites to get
 			// access to this cookie to do an CSRF attack.
-			setcookie('hyphaCsrfToken', $this->csrfToken,
+			$name = $this->getCsrfTokenCookieName();
+			setcookie($name, $this->csrfToken,
 			          /* expire */ 0,
 			          /* path */ $this->getRequest()->getRootUrlPath(),
 				  /* domain */ "",
-				  /* secure */ $this->getRequest()->isSecure(),
+				  /* secure */ $secure,
 				  /* http_only */ true);
 		}
 


### PR DESCRIPTION
For HTTPS requests, cookies are marked as "secure", meaning they can no
longer be sent over HTTP. However, this means that that cookie name is
effectively unavailable (broken) for HTTP requests on the same domain.
In practice, this means in a dual HTTP/HTTPS setup, sessions would stop
working on HTTP once a session cookie was set up on HTTPS.

To prevent this, make sure that the cookie names are different between
HTTP and HTTPS. This effectively means that HTTP and HTTPS have
independent sessions running, which is probably what would be expected
(given they can't share the same session for security reasons).