### PR TITLE
peer_reviewed_article: Fix use of - in links in comments

### DIFF
--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -128,7 +128,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		self::STATUS_RETRACTED => [/*self::STATUS_DRAFT => 'to_draft'*/], // "to draft" is not supported yet
 	];
 
-	const URL_REGEX='/(https?:\/\/|www.)[\w\/-]+\.[\w\/-?=%.&#_]*[\w\/-?=%&#_]/iu';
+	const URL_REGEX='/(https?:\/\/|www.)[-\w\/]+\.[-\w\/?=%.&#_]*[-\w\/?=%&#_]/iu';
 	// [protocol://|www.] [word] . [suffix /path ?query&parameter=value#bookmark] [last char must not be a dot]
 	const MAX_COMMENT_LENGTH = 100 * 6; // Roughly hundred words
 	const MIN_COMMENT_STUB_LENGTH = self::MAX_COMMENT_LENGTH * 0.7;


### PR DESCRIPTION
The - was already included in the URL regex used to detect links in
comments, but because it was not at the start of the `[...]` regex
element, it was probably interpreted as a range dash rather than a
literal dash. Putting it at the front fixes this and allows dashes in
links as intended.