### PR TITLE
peer_reviewed_article: Fix comment links without https://

### DIFF
--- a/system/datatypes/peer_reviewed_article.php
+++ b/system/datatypes/peer_reviewed_article.php
@@ -128,7 +128,7 @@ class peer_reviewed_article extends HyphaDatatypePage {
 		self::STATUS_RETRACTED => [/*self::STATUS_DRAFT => 'to_draft'*/], // "to draft" is not supported yet
 	];
 
-	const URL_REGEX='/(https?:\/\/|www.)[-\w\/]+\.[-\w\/?=%.&#_]*[-\w\/?=%&#_]/iu';
+	const URL_REGEX='/((https?:\/\/)|www.)[-\w\/]+\.[-\w\/?=%.&#_]*[-\w\/?=%&#_]/iu';
 	// [protocol://|www.] [word] . [suffix /path ?query&parameter=value#bookmark] [last char must not be a dot]
 	const MAX_COMMENT_LENGTH = 100 * 6; // Roughly hundred words
 	const MIN_COMMENT_STUB_LENGTH = self::MAX_COMMENT_LENGTH * 0.7;
@@ -1442,8 +1442,10 @@ EOF;
 	protected function processCommentText($commentText){
 		$commentHtml = htmlspecialchars($commentText);
 		$tryToParseLinks = preg_replace_callback(self::URL_REGEX, function($matches) { // replace urls with links
-			$url = $matches[0];
-			return '<a href="' . $url . '" target="_blank">' . $url . '</a>';
+			$url = $text = $matches[0];
+			if (count($matches) < 3 || !$matches[2])
+				$url = 'https://' . $url;
+			return '<a href="' . $url . '" target="_blank">' . $text . '</a>';
 		}, $commentHtml);
 
 		if(!is_null($tryToParseLinks)) $commentHtml = $tryToParseLinks; // In case regex fails


### PR DESCRIPTION
These were previously detected, but then used as-is, making the browser
interpret them as relative links on the current domain, rather than
absolute links. This is fixed by using an extra regex capture to detect
these urls and insert https:// if no protocol is already there.