### PR TITLE
Replace http:// by https:// where necessary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The hypha homepage can be found at [hypha.net](https://hypha.net).
 
 ## Prerequisites
 
-Hypha needs Apache running, with php version 5.6 or above.
+Hypha needs Apache running, with php version 7.2 or above.
 
 ## Basic Installation
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ a community but scares off 90% is a bug, rather than a feature.
 
 ## Homepage
 
-The hypha homepage can be found at [hypha.net](http://hypha.net).
+The hypha homepage can be found at [hypha.net](https://hypha.net).
 
 ## Prerequisites
 
@@ -25,12 +25,12 @@ Hypha needs Apache running, with php version 5.6 or above.
 ## Basic Installation
 
 The easiest way to install hypha is probably to follow the instructions on
-(http://hypha.net/hypha.php)[http://hypha.net/hypha.php]. This script packages a fully self-contained copy of hypha
+(https://hypha.net/hypha.php)[https://hypha.net/hypha.php]. This script packages a fully self-contained copy of hypha
 in a single monolithic php file. If you drop this file on a server and call it from a browser it will extract all
 necessary files and configure your site according to a few settings to have to enter. The script guides you through the
 installation process step by step.
 
-Your url should look like this `http://<address-of-your-apache>/index.php`
+Your url should look like this `https://<address-of-your-apache>/index.php`
 
 ## Advanced Install Though Git
 
@@ -39,4 +39,4 @@ Your url should look like this `http://<address-of-your-apache>/index.php`
    issuing a `git clone https://github.com/PlanBCode/hypha.git .` from the commandline in that folder.
 2. Set write permissions to the folder `data/`, e.g. by issuing a `chmod -R 777 .`
 3. Navigate to your web-folder in a browser to open `index.php` provided by hypha, and follow instructions from there.
-   Your url should look like this `http://<address-of-your-apache>/index.php`.
+   Your url should look like this `https://<address-of-your-apache>/index.php`.

--- a/documentation.txt
+++ b/documentation.txt
@@ -26,7 +26,7 @@ Simple installation:
 Uploading one fully self contained file is the goal.
 
 Open source:
-All code is available under a <Simple Public License at http://opensource.org/licenses/Simple-2.0> at <http://git.giplt.nl>
+All code is available under a <Simple Public License at https://opensource.org/license/Simple-2.0> at <http://git.giplt.nl>
 
 No content license:
 Your data is not owned by some big company but by you (or by your webhosting provider, depending on your contract with them)

--- a/hypha.php
+++ b/hypha.php
@@ -1,7 +1,7 @@
 <?php
 	// HYPHA
 	// hypha is a simple and user friendly cms with wiki and mailinglist functionality
-	// it makes use of php5, javascript and xml and is distributed as a monolithic php script
+	// it makes use of php7, javascript and xml and is distributed as a monolithic php script
 	// the project homepage is www.hypha.net
 	//
 	// INSTALL
@@ -26,7 +26,7 @@
 	//
 	// LICENSE
 	// the script was written by Harmen G. Zijp and is distributed under the Simple Public License 2.0
-	// which can be found on http://www.opensource.org/licenses/simpl-2.0.html
+	// which can be found on https://opensource.org/license/SimPL-2.0
 	// acknowledgements:
 	// - xhtml compliant javascript editor: wymeditor - http://www.wymeditor.org
 	// - htmldiff routine by Paul Butler
@@ -255,7 +255,7 @@
 			$header = $xml->createElement('header', $_POST['setupTitle']);
 			$hypha->appendChild($header);
 			$footer = $xml->createElement('footer', '');
-			setNodeHtml($footer, '<a href="https://creativecommons.org/licenses/by-sa/3.0/"><img alt="Creative Commons License" style="border-width: 0pt; float: right; margin-left: 5px;" src="https://i.creativecommons.org/l/by-sa/3.0/88x31.png" /></a> This work is licensed under a <a href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>. Website powered by <a href="http://www.hypha.net">hypha</a>.');
+			setNodeHtml($footer, '<a href="https://creativecommons.org/licenses/by-sa/3.0/"><img alt="Creative Commons License" style="border-width: 0pt; float: right; margin-left: 5px;" src="https://i.creativecommons.org/l/by-sa/3.0/88x31.png" /></a> This work is licensed under a <a href="https://creativecommons.org/licenses/by-sa/3.0/">Creative Commons Attribution-ShareAlike 3.0 Unported License</a>. Website powered by <a href="https://www.hypha.net">hypha</a>.');
 			$hypha->appendChild($footer);
 			$menu = $xml->createElement('menu', '');
 			setNodeHtml($menu, '<a href="hypha:'.$id.'"/>');

--- a/index.php
+++ b/index.php
@@ -48,7 +48,7 @@
 
 	/*
 		Group: Stage 3 - Get query and handle direct file requests
-		Here we extract our page query from the php $_SERVER data. Page requests should be formatted in a directory like structure, e.g. http://www.dom.ain/en/home/edit, the first level usually being a language id, the second level begin a page id, and the third level being an optional view.
+		Here we extract our page query from the php $_SERVER data. Page requests should be formatted in a directory like structure, e.g. https://www.dom.ain/en/home/edit, the first level usually being a language id, the second level begin a page id, and the third level being an optional view.
 		Some requests don't need the whole script to run. Certain file requests (css, javascript) can be handled directly here.
 	*/
 

--- a/system/core/HyphaRequest.php
+++ b/system/core/HyphaRequest.php
@@ -52,7 +52,7 @@
 
 			/**
 			 * in case of hypha instance in the root
-			 * request uri: http://www.my-org.net/en/my-page?foo=bar
+			 * request uri: https://www.my-org.net/en/my-page?foo=bar
 			 * $_SERVER['SCRIPT_NAME'] is expected to be "/index.php"
 			 * $_SERVER['REQUEST_URI'] is expected to be "/en/my-page?foo=bar"
 			 * $rootUrlPath will be "/"
@@ -60,7 +60,7 @@
 			 */
 			/**
 			 * in case of hypha instance in sub directory
-			 * request uri: http://www.my-org.net/my-hypha/en/my-page?foo=bar
+			 * request uri: https://www.my-org.net/my-hypha/en/my-page?foo=bar
 			 * $_SERVER['SCRIPT_NAME'] is expected to be "/my-hypha/index.php"
 			 * $_SERVER['REQUEST_URI'] is expected to be "/my-hypha/en/my-page?foo=bar"
 			 * $rootUrlPath will be "/my-hypha/"


### PR DESCRIPTION
Hypha contains some http protocol links, whereas https is nowadays the standard.